### PR TITLE
Fixing error handling in EnsemblePipeline in case of NaN labels

### DIFF
--- a/InnerEye/ML/pipelines/scalar_inference.py
+++ b/InnerEye/ML/pipelines/scalar_inference.py
@@ -177,9 +177,11 @@ class ScalarEnsemblePipeline(ScalarInferencePipelineBase):
         if len(set(map(tuple, [result.subject_ids for result in results]))) > 1:  # type: ignore
             raise ValueError("Trying to aggregate results for different subject ids.")
         subject_ids = results[0].subject_ids
-        # check that we have the same subject ids
+        # check that we have the same labels
         for result in results:
-            if not torch.equal(results[0].labels, result.labels):
+            # Using allclose() instead of equal() because we can have NaN in the labels (in which case
+            # equal() would return False).
+            if not torch.allclose(results[0].labels, result.labels, atol=0, rtol=0, equal_nan=True):
                 raise ValueError("Trying to aggregate results but ground truth does not match across samples.")
         labels = results[0].labels
 


### PR DESCRIPTION
Fixing error handling in EnsemblePipeline in case of NaN labels.
The predict function inside the ScalarEnsemblePipeline checks for consistency of labels across individual predictions in an ensemble run. If the labels contain NaNs, this check wrongly raised an error. This PR fixes this. 