### PR TITLE
Do not persist model outputs across epochs

### DIFF
--- a/InnerEye/Common/common_util.py
+++ b/InnerEye/Common/common_util.py
@@ -135,7 +135,8 @@ class ModelProcessing(Enum):
     ENSEMBLE_CREATION = 'ensemble_creation'
 
 
-def get_epoch_results_path(epoch: int, mode: ModelExecutionMode, model_proc: ModelProcessing = ModelProcessing.DEFAULT) -> Path:
+def get_epoch_results_path(epoch: int, mode: ModelExecutionMode,
+                           model_proc: ModelProcessing = ModelProcessing.DEFAULT) -> Path:
     """
     For a given model execution mode, and an epoch index, creates the relative results path
     in the form epoch_x/(Train, Test or Val)

--- a/InnerEye/ML/model_training.py
+++ b/InnerEye/ML/model_training.py
@@ -145,7 +145,7 @@ def model_train(config: ModelConfigBase, run_recovery: Optional[RunRecovery] = N
                                     in_training_mode=True)
         training_steps = create_model_training_steps(config, train_val_params)
         train_epoch_results = train_or_validate_epoch(training_steps)
-        train_results_per_epoch.append(train_epoch_results)
+        train_results_per_epoch.append(train_epoch_results.metrics)
 
         metrics.validate_and_store_model_parameters(writers.train, epoch, model)
         # Run without adjusting weights on the validation set
@@ -158,8 +158,7 @@ def model_train(config: ModelConfigBase, run_recovery: Optional[RunRecovery] = N
 
         training_steps = create_model_training_steps(config, train_val_params)
         val_epoch_results = train_or_validate_epoch(training_steps)
-        if train_val_params.save_metrics:
-            val_results_per_epoch.append(val_epoch_results)
+        val_results_per_epoch.append(val_epoch_results.metrics)
 
         if config.is_segmentation_model:
             metrics.store_epoch_stats_for_segmentation(config.outputs_folder, epoch, epoch_lrs,
@@ -173,7 +172,7 @@ def model_train(config: ModelConfigBase, run_recovery: Optional[RunRecovery] = N
                     temperature_scaling_steps(config, train_val_params, val_epoch_results)
                 optimal_temperature_scale_values.append(optimal_temperature)
                 # overwrite the metrics for the epoch with the metrics from the temperature scaled model
-                val_results_per_epoch.append(scaled_val_results)
+                val_results_per_epoch[-1] = scaled_val_results.metrics
 
             assert optimizer is not None
             save_checkpoint(model, optimizer, epoch, config)

--- a/InnerEye/ML/utils/training_util.py
+++ b/InnerEye/ML/utils/training_util.py
@@ -53,28 +53,10 @@ class ModelTrainingResults:
     """
     Stores the results from training, with the results on training and validation data for each training epoch.
     """
-    train_results_per_epoch: List[ModelOutputsAndMetricsForEpoch]
-    val_results_per_epoch: List[ModelOutputsAndMetricsForEpoch]
+    train_results_per_epoch: List[MetricsDict]
+    val_results_per_epoch: List[MetricsDict]
     learning_rates_per_epoch: List[List[float]]
     optimal_temperature_scale_values_per_checkpoint_epoch: List[float] = field(default_factory=list)
-
-    def get_logits(self, is_training: bool) -> torch.Tensor:
-        """
-        Get concatenated logits from each training/validation epoch.
-        :param is_training: return logits from model on the training set if True otherwise form the validation set
-        :return: concatenated logits from each training/validation epoch.
-        """
-        return torch.cat([x.get_logits() for x in
-                          (self.train_results_per_epoch if is_training else self.val_results_per_epoch)])
-
-    def get_labels(self, is_training: bool) -> torch.Tensor:
-        """
-        Get concatenated labels used for each training/validating epoch.
-        :param is_training: return training set labels if True otherwise return validation set labels
-        :return: concatenated labels used for each training/validating epoch.
-        """
-        return torch.cat([x.get_labels() for x in
-                          (self.train_results_per_epoch if is_training else self.val_results_per_epoch)])
 
     def __post_init__(self) -> None:
         common_util.check_properties_are_not_none(self)

--- a/Tests/ML/models/architectures/sequential/test_rnn_classifier.py
+++ b/Tests/ML/models/architectures/sequential/test_rnn_classifier.py
@@ -377,8 +377,8 @@ def test_rnn_classifier_via_config_2(test_output_dirs: TestOutputDirectories) ->
     config.dataset_data_frame = _get_mock_sequence_dataset(dataset_contents)
     results = model_train(config)
 
-    actual_train_loss = results.train_results_per_epoch[-1].metrics.values()[MetricType.LOSS.value][0]
-    actual_val_loss = results.val_results_per_epoch[-1].metrics.values()[MetricType.LOSS.value][0]
+    actual_train_loss = results.train_results_per_epoch[-1].values()[MetricType.LOSS.value][0]
+    actual_val_loss = results.val_results_per_epoch[-1].values()[MetricType.LOSS.value][0]
     print(f"Training loss after {config.num_epochs} epochs: {actual_train_loss}")
     print(f"Validation loss after {config.num_epochs} epochs: {actual_val_loss}")
     assert actual_train_loss <= expected_max_train_loss, "Training loss too high"

--- a/Tests/ML/models/test_2d_scalar_model.py
+++ b/Tests/ML/models/test_2d_scalar_model.py
@@ -47,8 +47,8 @@ def test_train_2d_classification_model(test_output_dirs: TestOutputDirectories,
     def extract_loss(results: List[MetricsDict]) -> List[float]:
         return [d.values()[MetricType.LOSS.value][0] for d in results]
 
-    actual_train_loss = extract_loss([x.metrics for x in model_training_result.train_results_per_epoch])
-    actual_val_loss = extract_loss([x.metrics for x in model_training_result.val_results_per_epoch])
+    actual_train_loss = extract_loss(model_training_result.train_results_per_epoch)
+    actual_val_loss = extract_loss(model_training_result.val_results_per_epoch)
     actual_learning_rates = list(flatten(model_training_result.learning_rates_per_epoch))
 
     assert actual_train_loss == pytest.approx(expected_train_loss, abs=1e-6)

--- a/Tests/ML/models/test_model_training.py
+++ b/Tests/ML/models/test_model_training.py
@@ -153,13 +153,13 @@ def _test_model_train(output_dirs: TestOutputDirectories,
     assert isinstance(model_training_result, ModelTrainingResults)
 
     # check to make sure training batches are NOT all the same across epochs
-    _check_patch_centers([x.metrics for x in model_training_result.train_results_per_epoch], should_equal=False)
+    _check_patch_centers(model_training_result.train_results_per_epoch, should_equal=False)
     # check to make sure validation batches are all the same across epochs
-    _check_patch_centers([x.metrics for x in model_training_result.val_results_per_epoch], should_equal=True)
-    assert isinstance(model_training_result.train_results_per_epoch[0].metrics, MetricsDict)
-    actual_train_losses = [m.metrics.get_single_metric(MetricType.LOSS)
+    _check_patch_centers(model_training_result.val_results_per_epoch, should_equal=True)
+    assert isinstance(model_training_result.train_results_per_epoch[0], MetricsDict)
+    actual_train_losses = [m.get_single_metric(MetricType.LOSS)
                            for m in model_training_result.train_results_per_epoch]
-    actual_val_losses = [m.metrics.get_single_metric(MetricType.LOSS)
+    actual_val_losses = [m.get_single_metric(MetricType.LOSS)
                          for m in model_training_result.val_results_per_epoch]
     print("actual_train_losses = {}".format(actual_train_losses))
     print("actual_val_losses = {}".format(actual_val_losses))

--- a/Tests/ML/models/test_scalar_model.py
+++ b/Tests/ML/models/test_scalar_model.py
@@ -73,8 +73,8 @@ def test_train_classification_model(test_output_dirs: TestOutputDirectories,
     def extract_loss(results: List[MetricsDict]) -> List[float]:
         return [d.values()[MetricType.LOSS.value][0] for d in results]
 
-    actual_train_loss = extract_loss([x.metrics for x in model_training_result.train_results_per_epoch])
-    actual_val_loss = extract_loss([x.metrics for x in model_training_result.val_results_per_epoch])
+    actual_train_loss = extract_loss(model_training_result.train_results_per_epoch)
+    actual_val_loss = extract_loss(model_training_result.val_results_per_epoch)
     actual_learning_rates = list(flatten(model_training_result.learning_rates_per_epoch))
     assert actual_train_loss == pytest.approx(expected_train_loss, abs=1e-6)
     assert actual_val_loss == pytest.approx(expected_val_loss, abs=1e-6)


### PR DESCRIPTION
This change removes the current model outputs persistence that is done across epochs, as this can lead out of memory issues.