### PR TITLE
Use AML Run API to download run artefacts instead of blobxfer

### DIFF
--- a/InnerEye/Azure/azure_config.py
+++ b/InnerEye/Azure/azure_config.py
@@ -19,13 +19,11 @@ from azureml.train.estimator import MMLBaseEstimator
 from azureml.train.hyperdrive import HyperDriveConfig
 from git import Repo
 
-from InnerEye.Azure.azure_util import get_results_blob_path, get_run_id, \
-    is_offline_run_context, to_azure_friendly_container_path
+from InnerEye.Azure.azure_util import is_offline_run_context
 from InnerEye.Azure.secrets_handling import APPLICATION_KEY, SecretsHandling, read_variables_from_yaml
 from InnerEye.Common import fixed_paths
 from InnerEye.Common.common_util import print_exception
 from InnerEye.Common.generic_parsing import GenericConfig
-from InnerEye.ML.utils.blobxfer_util import download_blobs
 
 
 class VMPriority(Enum):
@@ -256,33 +254,6 @@ class AzureConfig(GenericConfig):
             service_principal_id=self.application_id,
             service_principal_password=application_key)
 
-    def download_outputs_from_run(self, blobs_path: Path,
-                                  destination: Path,
-                                  run: Optional[Run] = None,
-                                  is_file: bool = False) -> Path:
-        """
-        Download the blobs from the run's storage container / DEFAULT_AML_UPLOAD_DIR.
-        Silently returns for offline runs.
-        :param blobs_path: Blobs path in DEFAULT_AML_UPLOAD_DIR of the run's storage container to download from
-        :param run: Run to download from (default to current run if None)
-        :param destination: Local path to save the downloaded blobs to
-        :param is_file: Set to True if downloading a single file.
-        :return: Destination root to the downloaded files
-        """
-        if self.storage_account is None:
-            raise ValueError("self.storage_account cannot be None")
-        key = self.get_storage_account_key()
-        if key is None:
-            raise ValueError("self.storage_account_key cannot be None")
-        return download_blobs(
-            account=self.storage_account,
-            account_key=key,
-            blobs_root_path=to_azure_friendly_container_path(
-                Path(get_results_blob_path(get_run_id(run))) / fixed_paths.DEFAULT_AML_UPLOAD_DIR / blobs_path
-            ),
-            destination=destination,
-            is_file=is_file
-        )
 
 
 @dataclass

--- a/InnerEye/Azure/run_pytest.py
+++ b/InnerEye/Azure/run_pytest.py
@@ -50,9 +50,6 @@ def download_pytest_result(azure_config: AzureConfig, run: Run, destination_fold
     """
     logging.info(f"Downloading pytest result file: {PYTEST_RESULTS_FILE}")
     try:
-        return azure_config.download_outputs_from_run(PYTEST_RESULTS_FILE,
-                                                      destination=destination_folder,
-                                                      run=run,
-                                                      is_file=True)
+        run.download_file(PYTEST_RESULTS_FILE, str(destination_folder), _validate_checksum=True)
     except:
         raise ValueError(f"No pytest result file {PYTEST_RESULTS_FILE} was found for run {run.id}")

--- a/InnerEye/ML/baselines_util.py
+++ b/InnerEye/ML/baselines_util.py
@@ -15,7 +15,8 @@ from InnerEye.Azure.azure_util import AZUREML_RUN_FOLDER_PREFIX, fetch_run, stri
 from InnerEye.Common import common_util
 from InnerEye.Common.Statistics import wilcoxon_signed_rank_test
 from InnerEye.Common.Statistics.wilcoxon_signed_rank_test import WilcoxonTestConfig
-from InnerEye.Common.common_util import BASELINE_WILCOXON_RESULTS_FILE, ENSEMBLE_SPLIT_NAME, EPOCH_FOLDER_NAME_PATTERN, \
+from InnerEye.Common.common_util import BASELINE_WILCOXON_RESULTS_FILE, ENSEMBLE_SPLIT_NAME, \
+    EPOCH_FOLDER_NAME_PATTERN, \
     FULL_METRICS_DATAFRAME_FILE, \
     METRICS_FILE_NAME, \
     ModelProcessing, OTHER_RUNS_SUBDIR_NAME, remove_file_or_directory
@@ -169,8 +170,8 @@ def get_comparison_baselines(outputs_folder: Path, azure_config: AzureConfig,
         # Look for dataset.csv inside epoch_NNN/Test, epoch_NNN/ and at top level
         for blob_path_parent in step_up_directories(blob_path):
             try:
-                comparison_dataset_path = azure_config.download_outputs_from_run(
-                    blob_path_parent / DATASET_CSV_FILE_NAME, destination_folder, run, True)
+                comparison_dataset_path = run.download_file(
+                    blob_path_parent / DATASET_CSV_FILE_NAME, destination_folder, True)
                 break
             except ValueError:
                 logging.warning(f"cannot find {DATASET_CSV_FILE_NAME} at {blob_path_parent} in {run_rec_id}")
@@ -182,8 +183,8 @@ def get_comparison_baselines(outputs_folder: Path, azure_config: AzureConfig,
                 logging.warning(f"cannot find {DATASET_CSV_FILE_NAME} at or above {blob_path} in {run_rec_id}")
         # Look for epoch_NNN/Test/metrics.csv
         try:
-            comparison_metrics_path = azure_config.download_outputs_from_run(
-                blob_path / METRICS_FILE_NAME, destination_folder, run, True)
+            comparison_metrics_path = run.download_file(
+                blob_path / METRICS_FILE_NAME, destination_folder, True)
         except ValueError:
             logging.warning(f"cannot find {METRICS_FILE_NAME} at {blob_path} in {run_rec_id}")
         # If both dataset.csv and metrics.csv were downloaded successfully, read their contents and

--- a/InnerEye/ML/surface_distance_heatmaps.py
+++ b/InnerEye/ML/surface_distance_heatmaps.py
@@ -66,11 +66,7 @@ def load_predictions(run_type: SurfaceDistanceRunType, azure_config: AzureConfig
         for (subject_id, structure_name, dice_score, _) in worst_performers:
             subject_prefix = sd_util.get_subject_prefix(model_config, execution_mode, subject_id)
             # if not already present, download data for subject
-            azure_config.download_outputs_from_run(
-                blobs_path=subject_prefix,
-                destination=output_dir,
-                run=first_child_run
-            )
+            first_child_run.download_files(str(subject_prefix), str(output_dir))
 
             # check it has been downloaded
             segmentation_path = output_dir / subject_prefix / f"{structure_name}.nii.gz"

--- a/InnerEye/ML/utils/run_recovery.py
+++ b/InnerEye/ML/utils/run_recovery.py
@@ -86,11 +86,7 @@ class RunRecovery:
             root_output_dir = Path(config.checkpoint_folder) / run.id
             checkpoint_subdir_name = None
         # download checkpoints for the run
-        azure_config.download_outputs_from_run(
-            blobs_path=Path(CHECKPOINT_FOLDER),
-            destination=root_output_dir,
-            run=run
-        )
+        run.download_files(CHECKPOINT_FOLDER, str(root_output_dir))
         if len(child_runs) > 0:
             tag_to_use = 'cross_validation_split_index'
             can_use_split_indices = tag_values_all_distinct(child_runs, tag_to_use)
@@ -106,11 +102,7 @@ class RunRecovery:
                         child_dst = root_output_dir / subdir / checkpoint_subdir_name
                     else:
                         child_dst = root_output_dir / subdir
-                    azure_config.download_outputs_from_run(
-                        blobs_path=Path(CHECKPOINT_FOLDER),
-                        destination=child_dst,
-                        run=child
-                    )
+                    child.download_files(CHECKPOINT_FOLDER, str(child_dst))
                 child_runs_checkpoints_roots.append(child_dst)
             return RunRecovery(checkpoints_roots=child_runs_checkpoints_roots)
         else:

--- a/InnerEye/ML/visualizers/plot_cross_validation.py
+++ b/InnerEye/ML/visualizers/plot_cross_validation.py
@@ -240,12 +240,7 @@ class PlotCrossValidationConfig(GenericConfig):
             return None
         else:
             try:
-                return self.azure_config.download_outputs_from_run(
-                    blobs_path=blob_path,
-                    destination=destination,
-                    run=run,
-                    is_file=True
-                )
+                return run.download_file(str(blob_path), str(destination), True)
             except Exception as ex:
                 logging.warning(f"File {blob_to_download} not found in output of run {run.id}: {ex}")
                 return None


### PR DESCRIPTION
- This change migrates the currently blobxfer usage to download AML run output blobs using the AML Run API.