### PR TITLE
Allow private settings files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ dmypy.json
 .idea/workspace.xml
 .idea/deployment.xml
 InnerEyeTestVariables.txt
+InnerEyePrivateSettings.yml
 Tests/ML/test_outputs
 /test_outputs
 /run_outputs

--- a/.idea/runConfigurations/Template__Submit_image_for_inference.xml
+++ b/.idea/runConfigurations/Template__Submit_image_for_inference.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Template: Submit image for inference" type="PythonConfigurationType" factoryName="Python">
+    <module name="InnerEye-DeepLearning" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="InnerEye/Scripts/submit_for_inference.py" />
+    <option name="PARAMETERS" value="--image_file Tests\ML\test_data\full_header_csv\rectum.nii.gz --model_id=BasicModel2Epochs:4486" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Template__Tensorboard_monitoring.xml
+++ b/.idea/runConfigurations/Template__Tensorboard_monitoring.xml
@@ -11,6 +11,7 @@
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="InnerEye/Azure/tensorboard_monitor.py" />
     <option name="PARAMETERS" value="--experiment_name=my_unet2d" />
     <option name="SHOW_COMMAND_LINE" value="false" />

--- a/.idea/runConfigurations/Template__Tensorboard_monitoring.xml
+++ b/.idea/runConfigurations/Template__Tensorboard_monitoring.xml
@@ -11,7 +11,6 @@
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
-    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="InnerEye/Azure/tensorboard_monitor.py" />
     <option name="PARAMETERS" value="--experiment_name=my_unet2d" />
     <option name="SHOW_COMMAND_LINE" value="false" />

--- a/InnerEye/Azure/azure_config.py
+++ b/InnerEye/Azure/azure_config.py
@@ -181,7 +181,8 @@ class AzureConfig(GenericConfig):
         """
         config = AzureConfig(**read_all_settings(project_settings_file=yaml_file_path,
                                                  project_root=project_root))
-        config.project_root = project_root
+        if project_root:
+            config.project_root = project_root
         return config
 
     def get_dataset_storage_account_key(self) -> Optional[str]:

--- a/InnerEye/Azure/azure_config.py
+++ b/InnerEye/Azure/azure_config.py
@@ -22,6 +22,7 @@ from git import Repo
 from InnerEye.Azure.azure_util import is_offline_run_context
 from InnerEye.Azure.secrets_handling import APPLICATION_KEY, DATASETS_ACCOUNT_KEY, SecretsHandling, \
     read_all_settings
+from InnerEye.Common import fixed_paths
 from InnerEye.Common.generic_parsing import GenericConfig
 
 
@@ -116,9 +117,9 @@ class AzureConfig(GenericConfig):
     extra_code_directory: str = param.String(doc="Directory (relative to project root) containing code "
                                                  "(e.g. model config) to be included in the model for "
                                                  "inference. Ignored by default.")
-    project_root: Optional[Path] = param.ClassSelector(class_=Path, allow_None=True, default=None,
-                                                       doc="The root folder that contains all code of the project "
-                                                           "that starts the InnerEye run.")
+    project_root: Path = param.ClassSelector(class_=Path, default=fixed_paths.repository_root_directory(),
+                                             doc="The root folder that contains all code of the project "
+                                                 "that starts the InnerEye run.")
     _workspace: Workspace = param.ClassSelector(class_=Workspace,
                                                 doc="The cached workspace object that has been created in the first"
                                                     "call to get_workspace")

--- a/InnerEye/Azure/azure_runner.py
+++ b/InnerEye/Azure/azure_runner.py
@@ -24,7 +24,7 @@ from InnerEye.Azure.azure_config import AzureConfig, ParserResult, SourceConfig
 from InnerEye.Azure.azure_util import CROSS_VALIDATION_SPLIT_INDEX_TAG_KEY, RUN_RECOVERY_FROM_ID_KEY_NAME, \
     RUN_RECOVERY_ID_KEY_NAME, \
     merge_conda_dependencies
-from InnerEye.Azure.secrets_handling import read_variables_from_yaml
+from InnerEye.Azure.secrets_handling import read_all_settings
 from InnerEye.Azure.tensorboard_monitor import AMLTensorBoardMonitorConfig, monitor
 from InnerEye.Common.fixed_paths import AZUREML_DATASTORE_NAME
 from InnerEye.Common.generic_parsing import GenericConfig
@@ -334,11 +334,13 @@ def create_runner_parser(model_config_class: type = None) -> argparse.ArgumentPa
 
 def parse_args_and_add_yaml_variables(parser: ArgumentParser,
                                       yaml_config_file: Optional[Path] = None,
+                                      project_root: Optional[Path] = None,
                                       fail_on_unknown_args: bool = False,
                                       args: List[str] = None) -> ParserResult:
     """
     Reads arguments from sys.argv, modifies them with secrets from local YAML files,
     and parses them using the given argument parser.
+    :param project_root: The root folder for the whole project. Only used to access a private settings file.
     :param parser: The parser to use.
     :param yaml_config_file: The path to the YAML file that contains values to supply into sys.argv.
     :param fail_on_unknown_args: If True, raise an exception if the parser encounters an argument that it does not
@@ -346,7 +348,7 @@ def parse_args_and_add_yaml_variables(parser: ArgumentParser,
     :param args: arguments to parse
     :return: The parsed arguments, and overrides
     """
-    settings_from_yaml = read_variables_from_yaml(yaml_config_file)
+    settings_from_yaml = read_all_settings(yaml_config_file, project_root=project_root)
     return parse_arguments(parser,
                            settings_from_yaml=settings_from_yaml,
                            fail_on_unknown_args=fail_on_unknown_args,

--- a/InnerEye/Azure/secrets_handling.py
+++ b/InnerEye/Azure/secrets_handling.py
@@ -17,22 +17,14 @@ from InnerEye.Common import fixed_paths
 # is case sensitive.
 
 # The application key to access the subscription via ServicePrincipal authentication.
+from InnerEye.Common.fixed_paths import PRIVATE_SETTINGS_FILE
+
 APPLICATION_KEY = "APPLICATION_KEY"
 # The access key for the Azure storage account that holds the datasets.
 DATASETS_ACCOUNT_KEY = "DATASETS_ACCOUNT_KEY"
 
 # A list of all secrets that are stored in environment variables or local secrets files.
 SECRETS_IN_ENVIRONMENT = [APPLICATION_KEY, DATASETS_ACCOUNT_KEY]
-
-
-def set_environment_variables(variables: Dict[str, str]) -> None:
-    """
-    Creates an environment variable for each entry in the given dictionary. The dictionary key is the variable
-    name, it will be converted to uppercase before setting.
-    :param variables: The variable names and their associated values that should be set.
-    """
-    for name, value in variables.items():
-        os.environ[name.upper()] = value
 
 
 class SecretsHandling:
@@ -49,9 +41,9 @@ class SecretsHandling:
 
     def read_secrets_from_file(self) -> Optional[Dict[str, str]]:
         """
-        Reads the secrets from a file, and returns the relevant secrets as a dictionary.
-        Searches for the secrets file in the project root.
-        :return: A dictionary with secrets.
+        Reads the secrets from file in YAML format, and returns the contents as a dictionary. The YAML file is expected
+        in the project root directory.
+        :return: A dictionary with secrets, or None if the file does not exist.
         """
         secrets_file = self.project_root / fixed_paths.PROJECT_SECRETS_FILE
         if not secrets_file.is_file():
@@ -102,10 +94,53 @@ class SecretsHandling:
         return value
 
 
-def read_variables_from_yaml(yaml_file: Optional[Path] = None) -> Dict[str, Any]:
+def read_all_settings(project_settings_file: Optional[Path] = None,
+                      project_root: Optional[Path] = None) -> Dict[str, Any]:
+    """
+    Reads settings from files in YAML format, and returns the union of settings found. The first settings file
+    to read is `project_settings_file`. The second settings file is 'InnerEyePrivateSettings.yml' expected in
+     the `project_root` folder. Settings in the private settings file
+    override those in the project settings. Both settings files are expected in YAML format, with an entry called
+    'variables'.
+    :param project_settings_file: The first YAML settings file to read.
+    :param project_root: The folder that can contain a 'InnerEyePrivateSettings.yml' file.
+    :return: A dictionary mapping from string to variable value. The dictionary key is the union of variable names
+    found in the two settings files.
+    """
+    private_settings_file = None
+    if project_root and project_root.is_dir():
+        private_settings_file = project_root / PRIVATE_SETTINGS_FILE
+    return read_settings_and_merge(project_settings_file, private_settings_file)
+
+
+def read_settings_and_merge(project_settings_file: Optional[Path] = None,
+                            private_settings_file: Optional[Path] = None) -> Dict[str, Any]:
+    """
+    Reads settings from files in YAML format, and returns the union of settings found. First, the project settings
+    file is read into a dictionary, then the private settings file is read. Settings in the private settings file
+    override those in the project settings. Both settings files are expected in YAML format, with an entry called
+    'variables'.
+    :param project_settings_file: The first YAML settings file to read.
+    :param private_settings_file: The second YAML settings file to read. Settings in this file has higher priority.
+    :return: A dictionary mapping from string to variable value. The dictionary key is the union of variable names
+    found in the two settings files.
+    """
+    result = {}
+    if project_settings_file:
+        if not project_settings_file.is_file():
+            raise FileNotFoundError(f"Settings file does not exist: {project_settings_file}")
+        result = read_settings_yaml_file(yaml_file=project_settings_file)
+    if private_settings_file and private_settings_file.is_file():
+        dict2 = read_settings_yaml_file(yaml_file=private_settings_file)
+        for key, value in dict2.items():
+            result[key] = value
+    return result
+
+
+def read_settings_yaml_file(yaml_file: Path) -> Dict[str, Any]:
     """
     Reads a YAML file, that is expected to contain an entry 'variables'. Returns the dictionary for the 'variables'
-    section of the file. If the file name is not given, an empty dictionary will be returned.
+    section of the file.
     :param yaml_file: The yaml file to read.
     :return: A dictionary with the variables from the yaml file.
     """
@@ -116,4 +151,4 @@ def read_variables_from_yaml(yaml_file: Optional[Path] = None) -> Dict[str, Any]
     if v in yaml_contents:
         return cast(Dict[str, Any], yaml_contents[v])
     else:
-        raise KeyError(f"The Yaml file was expected to contain a section '{v}'")
+        raise KeyError(f"The Yaml file must contain a section '{v}', but that was not found in {yaml_file}")

--- a/InnerEye/Azure/secrets_handling.py
+++ b/InnerEye/Azure/secrets_handling.py
@@ -125,7 +125,7 @@ def read_settings_and_merge(project_settings_file: Optional[Path] = None,
     :return: A dictionary mapping from string to variable value. The dictionary key is the union of variable names
     found in the two settings files.
     """
-    result = {}
+    result = dict()
     if project_settings_file:
         if not project_settings_file.is_file():
             raise FileNotFoundError(f"Settings file does not exist: {project_settings_file}")

--- a/InnerEye/Common/Statistics/report_structure_extremes.py
+++ b/InnerEye/Common/Statistics/report_structure_extremes.py
@@ -28,13 +28,14 @@ import csv
 import os
 import sys
 from pathlib import Path
-from typing import Dict, Iterator, List, Set, TextIO, Tuple
+from typing import Dict, Iterator, List, Optional, Set, TextIO, Tuple
 
 import numpy as np
 import param
 from azure.storage.blob import BlockBlobService
 
 from InnerEye.Azure.azure_config import AzureConfig
+from InnerEye.Common import fixed_paths
 from InnerEye.Common.common_util import logging_to_stdout
 from InnerEye.Common.generic_parsing import GenericConfig
 from InnerEye.ML.utils.blobxfer_util import download_blobs
@@ -46,7 +47,8 @@ NIFTI_SUFFIX = ".nii.gz"
 
 class ReportStructureExtremesConfig(GenericConfig):
     dataset: str = param.String(default=".", doc="Dataset name or directory to process")
-    yaml_file: str = param.String(default="", doc="YAML file that contains settings to access Azure.")
+    settings: Path = param.ClassSelector(class_=Path, default=fixed_paths.SETTINGS_YAML_FILE,
+                                         doc="YAML file that contains settings to access Azure.")
 
 
 def populate_series_maps(dataset_csv_path: str) -> Tuple[Dict[str, str], Dict[str, str]]:
@@ -68,15 +70,20 @@ def open_with_header(path: str, path_set: Set[str]) -> TextIO:
     return file
 
 
-def report_structure_extremes(dataset_dir: str, yaml_file: str) -> None:
+def report_structure_extremes(dataset_dir: str,
+                              settings_yaml_file: Path,
+                              project_root: Optional[Path] = None) -> None:
     """
     Writes structure-extreme lines for the subjects in a directory.
     If there are any structures with missing slices, a ValueError is raised after writing all the lines.
     This allows a build failure to be triggered when such structures exist.
-    :param yaml_file: The path to the YAML file that contains all Azure-related options.
+    :param settings_yaml_file: The path to the YAML file that contains all Azure-related options.
     :param dataset_dir: directory containing subject subdirectories with integer names.
+    :param project_root: The root folder of the project that starts the script. This is only used to locate the
+    optional InnerEyePrivateSettings.yml file.
     """
-    azure_config = AzureConfig.from_yaml(yaml_file_path=Path(yaml_file))
+    azure_config = AzureConfig.from_yaml(yaml_file_path=settings_yaml_file,
+                                         project_root=project_root)
     download_dataset_directory(azure_config, dataset_dir)
     subjects: Set[int] = set()
     series_map = None
@@ -230,14 +237,17 @@ def derive_missing_ranges(presence: np.array) -> List[str]:
     return missing_ranges
 
 
-def main() -> None:
+def main(settings_yaml_file: Optional[Path] = None,
+         project_root: Optional[Path] = None) -> None:
     """
     Main function.
     """
     logging_to_stdout()
     config = ReportStructureExtremesConfig.parse_args()
-    report_structure_extremes(config.dataset, config.yaml_file)
+    report_structure_extremes(config.dataset,
+                              settings_yaml_file=settings_yaml_file or config.settings,
+                              project_root=project_root)
 
 
 if __name__ == '__main__':
-    main()
+    main(project_root=fixed_paths.repository_root_directory())

--- a/InnerEye/Common/Statistics/report_structure_extremes.py
+++ b/InnerEye/Common/Statistics/report_structure_extremes.py
@@ -70,20 +70,14 @@ def open_with_header(path: str, path_set: Set[str]) -> TextIO:
     return file
 
 
-def report_structure_extremes(dataset_dir: str,
-                              settings_yaml_file: Path,
-                              project_root: Optional[Path] = None) -> None:
+def report_structure_extremes(dataset_dir: str, azure_config: AzureConfig) -> None:
     """
     Writes structure-extreme lines for the subjects in a directory.
     If there are any structures with missing slices, a ValueError is raised after writing all the lines.
     This allows a build failure to be triggered when such structures exist.
-    :param settings_yaml_file: The path to the YAML file that contains all Azure-related options.
+    :param azure_config: An object with all necessary information for accessing Azure.
     :param dataset_dir: directory containing subject subdirectories with integer names.
-    :param project_root: The root folder of the project that starts the script. This is only used to locate the
-    optional InnerEyePrivateSettings.yml file.
     """
-    azure_config = AzureConfig.from_yaml(yaml_file_path=settings_yaml_file,
-                                         project_root=project_root)
     download_dataset_directory(azure_config, dataset_dir)
     subjects: Set[int] = set()
     series_map = None
@@ -244,9 +238,9 @@ def main(settings_yaml_file: Optional[Path] = None,
     """
     logging_to_stdout()
     config = ReportStructureExtremesConfig.parse_args()
-    report_structure_extremes(config.dataset,
-                              settings_yaml_file=settings_yaml_file or config.settings,
-                              project_root=project_root)
+    azure_config = AzureConfig.from_yaml(yaml_file_path=settings_yaml_file or config.settings,
+                                         project_root=project_root)
+    report_structure_extremes(config.dataset, azure_config)
 
 
 if __name__ == '__main__':

--- a/InnerEye/Common/fixed_paths.py
+++ b/InnerEye/Common/fixed_paths.py
@@ -45,8 +45,11 @@ ML_FULL_SOURCE_FOLDER_PATH = str(repository_root_directory() / ML_RELATIVE_SOURC
 
 VISUALIZATION_NOTEBOOK_PATH = os.path.join("ML", "visualizers", "gradcam_visualization.ipynb")
 
-# A file that contains secrets. This is expected to live in the repository root.
+# A file that contains secrets. This is expected to live in the root folder of the repository or project.
 PROJECT_SECRETS_FILE = "InnerEyeTestVariables.txt"
+# A file with additional settings that should not be added to source control.
+# This file is expected to live in the root folder of the repository or project.
+PRIVATE_SETTINGS_FILE = "InnerEyePrivateSettings.yml"
 
 INNEREYE_PACKAGE_ROOT = repository_root_directory(INNEREYE_PACKAGE_NAME)
 SETTINGS_YAML_FILE_NAME = "settings.yml"

--- a/InnerEye/ML/runner.py
+++ b/InnerEye/ML/runner.py
@@ -74,6 +74,9 @@ def suppress_logging_noise() -> None:
     logging.getLogger('urllib3').setLevel(logging.INFO)
     # AzureML prints too many details about logging metrics
     logging.getLogger('azureml').setLevel(logging.INFO)
+    # Jupyter notebook report generation
+    logging.getLogger('papermill').setLevel(logging.INFO)
+    logging.getLogger('nbconvert').setLevel(logging.INFO)
     # This is working around a spurious error message thrown by MKL, see
     # https://github.com/pytorch/pytorch/issues/37377
     os.environ['MKL_THREADING_LAYER'] = 'GNU'

--- a/InnerEye/ML/runner.py
+++ b/InnerEye/ML/runner.py
@@ -176,7 +176,7 @@ class Runner:
         plot_crossval_config = crossval_config_from_model_config(self.model_config)
         plot_crossval_config.run_recovery_id = PARENT_RUN_CONTEXT.tags[RUN_RECOVERY_ID_KEY_NAME]
         plot_crossval_config.outputs_directory = str(self.model_config.outputs_folder)
-        plot_crossval_config.train_yaml_path = str(self.yaml_config_file)
+        plot_crossval_config.settings_yaml_file = str(self.yaml_config_file)
         cross_val_results_root = plot_cross_validation(plot_crossval_config)
         if self.post_cross_validation_hook:
             self.post_cross_validation_hook(self.model_config, cross_val_results_root)
@@ -242,6 +242,7 @@ class Runner:
         parser1 = create_runner_parser()
         parser1_result = parse_args_and_add_yaml_variables(parser1,
                                                            yaml_config_file=self.yaml_config_file,
+                                                           project_root=self.project_root,
                                                            args=self.command_line_args,
                                                            fail_on_unknown_args=False)
         azure_config = AzureConfig(**parser1_result.args)

--- a/InnerEye/ML/visualizers/plot_cross_validation.py
+++ b/InnerEye/ML/visualizers/plot_cross_validation.py
@@ -189,7 +189,7 @@ class PlotCrossValidationConfig(GenericConfig):
         :return:
         """
         if self._azure_config is None:
-            self._azure_config = AzureConfig.from_yaml(Path(self.settings_yaml_file))
+            self._azure_config = AzureConfig.from_yaml(Path(self.settings_yaml_file), project_root=None)
         return self._azure_config
 
     def download_or_get_local_file(self,

--- a/InnerEye/ML/visualizers/plot_cross_validation.py
+++ b/InnerEye/ML/visualizers/plot_cross_validation.py
@@ -92,7 +92,7 @@ class PlotCrossValidationConfig(GenericConfig):
     """
     model_category: ModelCategory = param.ClassSelector(class_=ModelCategory,
                                                         default=ModelCategory.Segmentation,
-                                                         doc="The high-level model category described by this config.")
+                                                        doc="The high-level model category described by this config.")
     is_scalar: bool = param.Boolean(default=True,
                                     doc="Set to True if the model to evaluate is a classification model"
                                         "otherwise False for a regression model")
@@ -122,9 +122,9 @@ class PlotCrossValidationConfig(GenericConfig):
     ignore_subjects: List[int] = param.List(None, class_=int, bounds=(1, None), allow_None=True, instantiate=False,
                                             doc="List of the subject ids to ignore from the results")
     is_zero_index: bool = param.Boolean(True, doc="If True, start cross validation split indices from 0 otherwise 1")
-    train_yaml_path: str = param.String(default=str(fixed_paths.SETTINGS_YAML_FILE),
-                                        doc="Path to settings.yml file containing the Azure configuration "
-                                            "for the workspace")
+    settings_yaml_file: str = param.String(default=str(fixed_paths.SETTINGS_YAML_FILE),
+                                           doc="Path to settings.yml file containing the Azure configuration "
+                                               "for the workspace")
     _azure_config: Optional[AzureConfig] = \
         param.ClassSelector(class_=AzureConfig, allow_None=True,
                             doc="Azure-related options created from YAML file.")
@@ -189,7 +189,7 @@ class PlotCrossValidationConfig(GenericConfig):
         :return:
         """
         if self._azure_config is None:
-            self._azure_config = AzureConfig.from_yaml(Path(self.train_yaml_path))
+            self._azure_config = AzureConfig.from_yaml(Path(self.settings_yaml_file))
         return self._azure_config
 
     def download_or_get_local_file(self,

--- a/InnerEye/Scripts/submit_for_inference.py
+++ b/InnerEye/Scripts/submit_for_inference.py
@@ -15,9 +15,11 @@ from azureml.core import Experiment, Model
 
 from InnerEye.Azure.azure_config import AzureConfig, SourceConfig
 from InnerEye.Azure.azure_runner import create_estimator_from_configs
+from InnerEye.Common import fixed_paths
 from InnerEye.Common.common_util import logging_to_stdout
 from InnerEye.Common.fixed_paths import DEFAULT_RESULT_IMAGE_NAME, ENVIRONMENT_YAML_FILE_NAME
 from InnerEye.Common.generic_parsing import GenericConfig
+from InnerEye.ML.utils.io_util import MedicalImageFileType
 from score import DEFAULT_DATA_FOLDER, DEFAULT_TEST_IMAGE_NAME
 
 
@@ -27,26 +29,30 @@ class SubmitForInferenceConfig(GenericConfig):
     """
     experiment_name: str = param.String(default="model_inference",
                                         doc="Name of experiment the run should belong to")
-    model_id: str = param.String(doc="Id of model, e.g. Prostate:123")
-    image_file: Path = param.ClassSelector(class_=Path, doc="Image file to segment, ending in .nii.gz")
+    model_id: str = param.String(doc="Id of model, e.g. Prostate:123. Mandatory.")
+    image_file: Path = param.ClassSelector(class_=Path, doc="Image file to segment, ending in .nii.gz. Mandatory.")
     settings: Path = param.ClassSelector(class_=Path,
-                                         doc="File containing subscription details, typically your settings.yml")
-    download_folder: Optional[Path] = param.ClassSelector(default=None,
-                                                          class_=Path,
-                                                          doc="Folder into which to download the segmentation result")
+                                         doc="File containing Azure settings (typically your settings.yml). If not "
+                                             "provided, use the default settings file.")
+    download_folder: Optional[Path] = \
+        param.ClassSelector(class_=Path, default=None,
+                            doc="Folder into which to download the segmentation result. If this is provided, the "
+                                "script waits for the AzureML run to complete.")
     keep_upload_folder: bool = param.Boolean(
         default=False, doc="Whether to keep the temporary upload folder after the inference run is submitted")
+    cluster: str = param.String(doc="The name of the GPU cluster in which to run the experiment. If not provided, use "
+                                    "the cluster in the settings.yml file")
 
     def validate(self) -> None:
-        assert self.settings is not None
         # The image file must be specified, must exist, and must end in .nii.gz, i.e. be
         # a compressed Nifti file.
-        assert self.image_file is not None
-        if not self.image_file.exists():
+        assert self.image_file
+        if not self.image_file.is_file():
             raise FileNotFoundError(self.image_file)
         basename = str(self.image_file.name)
-        if not basename.endswith(".nii.gz"):
-            raise ValueError(f"Bad image file name, does not end with .nii.gz: {self.image_file.name}")
+        extension = MedicalImageFileType.NIFTI_COMPRESSED_GZ.value
+        if not basename.endswith(extension):
+            raise ValueError(f"Bad image file name, does not end with {extension}: {self.image_file.name}")
         # If the user wants the result downloaded, the download folder must already exist
         if self.download_folder is not None:
             assert self.download_folder.exists()
@@ -168,9 +174,12 @@ def main(args: Optional[List[str]] = None, project_root: Optional[Path] = None) 
     """
     logging_to_stdout()
     inference_config = SubmitForInferenceConfig.parse_args(args)
-    azure_config = AzureConfig.from_yaml(inference_config.settings, project_root=project_root)
+    settings = inference_config.settings or fixed_paths.SETTINGS_YAML_FILE
+    azure_config = AzureConfig.from_yaml(settings, project_root=project_root)
+    if inference_config.cluster:
+        azure_config.cluster = inference_config.cluster
     submit_for_inference(inference_config, azure_config)
 
 
 if __name__ == '__main__':
-    main()
+    main(project_root=fixed_paths.repository_root_directory())

--- a/InnerEye/Scripts/submit_for_inference.py
+++ b/InnerEye/Scripts/submit_for_inference.py
@@ -109,14 +109,15 @@ def choose_download_path(download_folder: Path) -> Path:
         base = ".".join([f"{components[0]}_{index:03d}"] + components[1:])
 
 
-def submit_for_inference(args: SubmitForInferenceConfig) -> Optional[Path]:
+def submit_for_inference(args: SubmitForInferenceConfig,
+                         project_root: Optional[Path] = None) -> Optional[Path]:
     """
     Create and submit an inference to AzureML, and optionally download the resulting segmentation.
     :param args: configuration, see SubmitForInferenceConfig
     :return: path to downloaded segmentation on local disc, or None if none.
     """
     logging.info(f"Building Azure configuration from {args.yaml_file}")
-    azure_config = AzureConfig.from_yaml(args.yaml_file)
+    azure_config = AzureConfig.from_yaml(args.yaml_file, project_root=project_root)
     logging.info("Getting workspace")
     workspace = azure_config.get_workspace()
     logging.info("Identifying model")
@@ -162,12 +163,13 @@ def submit_for_inference(args: SubmitForInferenceConfig) -> Optional[Path]:
     return download_path
 
 
-def main(args: Optional[List[str]] = None) -> None:
+def main(args: Optional[List[str]] = None, project_root: Optional[Path] = None) -> None:
     """
     Main function.
     """
     logging_to_stdout()
-    submit_for_inference(SubmitForInferenceConfig.parse_args(args))
+    submit_for_inference(SubmitForInferenceConfig.parse_args(args),
+                         project_root=project_root)
 
 
 if __name__ == '__main__':

--- a/InnerEye/Scripts/submit_for_inference.py
+++ b/InnerEye/Scripts/submit_for_inference.py
@@ -29,8 +29,8 @@ class SubmitForInferenceConfig(GenericConfig):
                                         doc="Name of experiment the run should belong to")
     model_id: str = param.String(doc="Id of model, e.g. Prostate:123")
     image_file: Path = param.ClassSelector(class_=Path, doc="Image file to segment, ending in .nii.gz")
-    yaml_file: Path = param.ClassSelector(
-        class_=Path, doc="File containing subscription details, typically your settings.yml")
+    settings: Path = param.ClassSelector(class_=Path,
+                                         doc="File containing subscription details, typically your settings.yml")
     download_folder: Optional[Path] = param.ClassSelector(default=None,
                                                           class_=Path,
                                                           doc="Folder into which to download the segmentation result")
@@ -38,7 +38,7 @@ class SubmitForInferenceConfig(GenericConfig):
         default=False, doc="Whether to keep the temporary upload folder after the inference run is submitted")
 
     def validate(self) -> None:
-        assert self.yaml_file is not None
+        assert self.settings is not None
         # The image file must be specified, must exist, and must end in .nii.gz, i.e. be
         # a compressed Nifti file.
         assert self.image_file is not None
@@ -109,15 +109,14 @@ def choose_download_path(download_folder: Path) -> Path:
         base = ".".join([f"{components[0]}_{index:03d}"] + components[1:])
 
 
-def submit_for_inference(args: SubmitForInferenceConfig,
-                         project_root: Optional[Path] = None) -> Optional[Path]:
+def submit_for_inference(args: SubmitForInferenceConfig, azure_config: AzureConfig) -> Optional[Path]:
     """
     Create and submit an inference to AzureML, and optionally download the resulting segmentation.
+    :param azure_config: An object with all necessary information for accessing Azure.
     :param args: configuration, see SubmitForInferenceConfig
     :return: path to downloaded segmentation on local disc, or None if none.
     """
-    logging.info(f"Building Azure configuration from {args.yaml_file}")
-    azure_config = AzureConfig.from_yaml(args.yaml_file, project_root=project_root)
+    logging.info(f"Building Azure configuration from {args.settings}")
     logging.info("Getting workspace")
     workspace = azure_config.get_workspace()
     logging.info("Identifying model")
@@ -168,8 +167,9 @@ def main(args: Optional[List[str]] = None, project_root: Optional[Path] = None) 
     Main function.
     """
     logging_to_stdout()
-    submit_for_inference(SubmitForInferenceConfig.parse_args(args),
-                         project_root=project_root)
+    inference_config = SubmitForInferenceConfig.parse_args(args)
+    azure_config = AzureConfig.from_yaml(inference_config.settings, project_root=project_root)
+    submit_for_inference(inference_config, azure_config)
 
 
 if __name__ == '__main__':

--- a/Tests/Azure/test_data/settings.yml
+++ b/Tests/Azure/test_data/settings.yml
@@ -1,2 +1,0 @@
-variables:
-  some_key: 'some_val'

--- a/Tests/Azure/test_data/settings_with_missing_section.yml
+++ b/Tests/Azure/test_data/settings_with_missing_section.yml
@@ -1,1 +1,0 @@
-some_key: 'some_val'

--- a/Tests/Azure/test_git.py
+++ b/Tests/Azure/test_git.py
@@ -20,7 +20,7 @@ def test_git_info() -> None:
     Test if git branch information can be read correctly.
     """
     logging_to_stdout(log_level=logging.DEBUG)
-    azure_config = AzureConfig.from_yaml(fixed_paths.SETTINGS_YAML_FILE)
+    azure_config = AzureConfig.from_yaml(fixed_paths.SETTINGS_YAML_FILE, project_root=None)
     azure_config.project_root = project_root
     assert azure_config.build_branch == ""
     assert azure_config.build_source_id == ""
@@ -41,7 +41,7 @@ def test_git_info_from_commandline() -> None:
     """
     Test if git branch information can be overriden on the commandline
     """
-    azure_config = AzureConfig.from_yaml(fixed_paths.SETTINGS_YAML_FILE)
+    azure_config = AzureConfig.from_yaml(fixed_paths.SETTINGS_YAML_FILE, project_root=None)
     azure_config.project_root = project_root
     azure_config.build_branch = "branch"
     azure_config.build_source_id = "id"

--- a/Tests/Azure/test_parsing.py
+++ b/Tests/Azure/test_parsing.py
@@ -89,8 +89,7 @@ def test_create_runner_parser(with_config: bool) -> None:
                  # Normally we don't use extra index URLs in InnerEye, hence this won't be set in YAML.
                  "--pip_extra_index_url=foo"]
     with mock.patch("sys.argv", [""] + args_list):
-        parser_result = parse_args_and_add_yaml_variables(azure_parser,
-                                                          yaml_config_file=fixed_paths.SETTINGS_YAML_FILE)
+        parser_result = parse_args_and_add_yaml_variables(azure_parser, yaml_config_file=fixed_paths.SETTINGS_YAML_FILE)
     azure_config = AzureConfig(**parser_result.args)
 
     # These values have been set on the commandline, to values that are not the parser defaults.

--- a/Tests/ML/runners/test_submit_for_inference.py
+++ b/Tests/ML/runners/test_submit_for_inference.py
@@ -21,7 +21,7 @@ from Tests.Common.test_util import DEFAULT_MODEL_ID_NUMERIC
 def test_submit_for_inference() -> None:
     args = ["--image_file", "Tests/ML/test_data/train_and_test_data/id1_channel1.nii.gz",
             "--model_id", DEFAULT_MODEL_ID_NUMERIC,
-            "--yaml_file", "InnerEye/settings.yml",
+            "--settings", "InnerEye/settings.yml",
             "--download_folder", "."]
     seg_path = Path(DEFAULT_RESULT_IMAGE_NAME)
     if seg_path.exists():

--- a/Tests/ML/util.py
+++ b/Tests/ML/util.py
@@ -172,7 +172,8 @@ def get_default_azure_config() -> AzureConfig:
     """
     Gets the Azure-related configuration options, using the default settings file settings.yaml.
     """
-    return AzureConfig.from_yaml(yaml_file_path=fixed_paths.SETTINGS_YAML_FILE)
+    return AzureConfig.from_yaml(yaml_file_path=fixed_paths.SETTINGS_YAML_FILE,
+                                 project_root=fixed_paths.repository_root_directory())
 
 
 def get_default_workspace() -> Workspace:

--- a/azure-pipelines/build.yaml
+++ b/azure-pipelines/build.yaml
@@ -45,6 +45,13 @@ steps:
     condition: succeededOrFailed()
     displayName: mypy
 
+  # Pytest needs subscription information directly in settings.yml. Local package install will cause use of
+  # the wrong default project root, hence InnerEyePrivateSettings.yml can't be picked up.
+  - bash: |
+      sed -i -e "s/subscription_id: ''/subscription_id: '$(InnerEyeDevSubscriptionID)'/" InnerEye/settings.yml
+      sed -i -e "s/application_id: ''/application_id: '$(InnerEyeDeepLearningServicePrincipalID)'/" InnerEye/settings.yml
+    displayName: Store subscription in settings.yml
+
   - bash: |
       source activate InnerEye
       python setup.py install

--- a/azure-pipelines/checkout_and_settings.yml
+++ b/azure-pipelines/checkout_and_settings.yml
@@ -26,4 +26,4 @@ steps:
 
   - bash: |
       echo -e "variables:\n  subscription_id: '$(InnerEyeDevSubscriptionID)'\n  application_id: '$(InnerEyeDeepLearningServicePrincipalID)'" > InnerEyePrivateSettings.yml
-    displayName: Provide subscription information
+    displayName: Store subscription in InnerEyePrivateSettings.yml

--- a/azure-pipelines/checkout_and_settings.yml
+++ b/azure-pipelines/checkout_and_settings.yml
@@ -25,6 +25,5 @@ steps:
     displayName: Take ownership of conda installation
 
   - bash: |
-      sed -i -e "s/subscription_id: ''/subscription_id: '$(InnerEyeDevSubscriptionID)'/" InnerEye/settings.yml
-      sed -i -e "s/application_id: ''/application_id: '$(InnerEyeDeepLearningServicePrincipalID)'/" InnerEye/settings.yml
+      echo -e "variables:\n  subscription_id: '$(InnerEyeDevSubscriptionID)'\n  application_id: '$(InnerEyeDeepLearningServicePrincipalID)'" > InnerEyePrivateSettings.yml
     displayName: Provide subscription information

--- a/azure-pipelines/train_via_submodule.yml
+++ b/azure-pipelines/train_via_submodule.yml
@@ -8,8 +8,9 @@ steps:
       source activate AzureRunner
       mkdir $(Agent.TempDirectory)/InnerEye/
       cp -r $(Build.SourcesDirectory)/TestSubmodule $(Agent.TempDirectory)/InnerEye/TestSubmodule
-      cp -r $(Build.SourcesDirectory)/TestSubmodule/environment.yml $(Agent.TempDirectory)/InnerEye
       cp -r $(Build.SourcesDirectory) $(Agent.TempDirectory)/InnerEye/Submodule
+      cp -r $(Build.SourcesDirectory)/TestSubmodule/environment.yml $(Agent.TempDirectory)/InnerEye
+      cp -r $(Build.SourcesDirectory)/InnerEyePrivateSettings.yml $(Agent.TempDirectory)/InnerEye
       branch_prefix="refs/heads/"
       full_branch_name=$(Build.SourceBranch)
       branch_name_without_prefix=${full_branch_name#$branch_prefix}

--- a/docs/building_models.md
+++ b/docs/building_models.md
@@ -147,7 +147,7 @@ Alternatively, to submit an AzureML run to apply a model to a single image on yo
 you can use the script `submit_for_inference.py`, with a command of this form:
 ```shell script
 python InnerEye/Scripts/submit_for_inference.py --image_file ~/somewhere/ct.nii.gz --model_id Prostate:555 \
-  --yaml_file ../somewhere_else/settings.yml --download_folder ~/my_existing_folder
+  --settings ../somewhere_else/settings.yml --download_folder ~/my_existing_folder
 ```
 
 ### Model Ensembles


### PR DESCRIPTION
Add the capability to not check in the complete `settings.yml` file, and fill in the missing ones via the file `InnerEyePrivateSettings.yml` file in the repository root.