### PR TITLE
Read MONOCHROME1 Dicom images

### DIFF
--- a/Tests/ML/utils/test_io_util.py
+++ b/Tests/ML/utils/test_io_util.py
@@ -198,76 +198,108 @@ def write_test_dicom(array: np.ndarray, path: Path) -> None:
     This function DOES NOT create a usable Dicom file and is meant only for testing: tags are set to
     random/default values so that pydicom does not complain when reading the file.
     """
-
     image = sitk.GetImageFromArray(array)
     writer = sitk.ImageFileWriter()
-    writer.KeepOriginalImageUIDOn()
     writer.SetFileName(str(path))
     writer.Execute(image)
 
 
-def test_load_dicom_image_ones(test_output_dirs: TestOutputDirectories) -> None:
+def get_mock_function(monochrome2: bool, bits_stored: Optional[int] = None):
     """
-    Test loading of 2D Dicom images filled with (uint16) ones.
+    SimpleITK does not allow us to set Photometric Interpretation and Stored Bits, so we need to mock the reader to
+    make sure the right attributes are returned.
+    """
+    get_metadata_function = sitk.ImageFileReader.GetMetaData
+
+    def mock_function(image_reader: sitk.ImageFileReader, key: str):
+        if bits_stored and key == "0028|0101":
+            return bits_stored
+        elif not monochrome2 and key == "0028|0004":
+            return "MONOCHROME1"
+        else:
+            return get_metadata_function(image_reader, key)
+
+    return mock_function
+
+
+@pytest.mark.parametrize("signed", [True, False])
+@pytest.mark.parametrize("monochrome2", [True, False])
+def test_load_dicom_image_ones(test_output_dirs: TestOutputDirectories,
+                               signed: bool, monochrome2: bool) -> None:
+    """
+    Test loading of 2D Dicom images filled with binary array of type (uint16) and (int16).
     """
     array_size = (20, 30)
-    array = np.ones(array_size, dtype='uint16')
-    array[::2] = 0
+    if not signed:
+        array = np.ones(array_size, dtype='uint16')
+        array[::2] = 0
+    else:
+        array = -1 * np.ones(array_size, dtype='int16')
+        array[::2] = 0
+
     assert array.shape == array_size
+
+    if monochrome2:
+        to_write = array
+    else:
+        if not signed:
+            to_write = np.zeros(array_size, dtype='uint16')
+            to_write[::2] = 1
+        else:
+            to_write = np.zeros(array_size, dtype='int16')
+            to_write[::2] = -1
 
     dcm_file = Path(test_output_dirs.root_dir) / "file.dcm"
     assert is_dicom_file_path(dcm_file)
-    write_test_dicom(array, dcm_file)
+    write_test_dicom(array=to_write, path=dcm_file)
 
-    image = load_dicom_image(dcm_file)
-    assert image.ndim == 3 and image.shape == (1, ) + array_size
-    assert np.array_equal(image, array[None, ...])
+    with mock.patch.object(sitk.ImageFileReader, 'GetMetaData',
+                           new=get_mock_function(monochrome2=monochrome2, bits_stored=1)):
+        image = load_dicom_image(dcm_file)
+        assert image.ndim == 3 and image.shape == (1, ) + array_size
+        assert np.array_equal(image, array[None, ...])
 
-    image_and_segmentation = load_image_in_known_formats(dcm_file, load_segmentation=False)
-    assert image_and_segmentation.images.ndim == 3 and image_and_segmentation.images.shape == (1,) + array_size
-    assert np.array_equal(image_and_segmentation.images, array[None, ...])
+        image_and_segmentation = load_image_in_known_formats(dcm_file, load_segmentation=False)
+        assert image_and_segmentation.images.ndim == 3 and image_and_segmentation.images.shape == (1,) + array_size
+        assert np.array_equal(image_and_segmentation.images, array[None, ...])
 
 
-def test_load_dicom_image_random_unsigned(test_output_dirs: TestOutputDirectories) -> None:
+@pytest.mark.parametrize("signed", [True, False])
+@pytest.mark.parametrize("monochrome2", [True, False])
+@pytest.mark.parametrize("bits_stored", [14, 16])
+def test_load_dicom_image_random(test_output_dirs: TestOutputDirectories,
+                                 signed: bool, monochrome2: bool, bits_stored: int) -> None:
     """
-    Test loading of 2D Dicom images of type (uint16).
+    Test loading of 2D Dicom images of type (uint16) and (int16).
     """
     array_size = (20, 30)
-    array = np.random.randint(0, 200, size=array_size, dtype='uint16')
+    if not signed:
+        array = np.random.randint(0, 200, size=array_size, dtype='uint16')
+    else:
+        array = np.random.randint(-200, 200, size=array_size, dtype='int16')
     assert array.shape == array_size
+
+    if monochrome2:
+        to_write = array
+    else:
+        if not signed:
+            to_write = 2**bits_stored - 1 - array
+        else:
+            to_write = -1 * array - 1
 
     dcm_file = Path(test_output_dirs.root_dir) / "file.dcm"
     assert is_dicom_file_path(dcm_file)
-    write_test_dicom(array, dcm_file)
+    write_test_dicom(array=to_write, path=dcm_file)
 
-    image = load_dicom_image(dcm_file)
-    assert image.ndim == 3 and image.shape == (1,) + array_size
-    assert np.array_equal(image, array[None, ...])
+    with mock.patch.object(sitk.ImageFileReader, 'GetMetaData',
+                           new=get_mock_function(monochrome2=monochrome2, bits_stored=bits_stored)):
+        image = load_dicom_image(dcm_file)
+        assert image.ndim == 3 and image.shape == (1,) + array_size
+        assert np.array_equal(image, array[None, ...])
 
-    image_and_segmentation = load_image_in_known_formats(dcm_file, load_segmentation=False)
-    assert image_and_segmentation.images.ndim == 3 and image_and_segmentation.images.shape == (1,) + array_size
-    assert np.array_equal(image_and_segmentation.images, array[None, ...])
-
-
-def test_load_dicom_image_random_signed(test_output_dirs: TestOutputDirectories) -> None:
-    """
-    Test loading of 2D Dicom images of type (int16).
-    """
-    array_size = (20, 30)
-    array = np.random.randint(-200, 200, size=array_size, dtype='int16')
-    assert array.shape == array_size
-
-    dcm_file = Path(test_output_dirs.root_dir) / "file.dcm"
-    assert is_dicom_file_path(dcm_file)
-    write_test_dicom(array, dcm_file)
-
-    image = load_dicom_image(dcm_file)
-    assert image.ndim == 3 and image.shape == (1,) + array_size
-    assert np.array_equal(image, array[None, ...])
-
-    image_and_segmentation = load_image_in_known_formats(dcm_file, load_segmentation=False)
-    assert image_and_segmentation.images.ndim == 3 and image_and_segmentation.images.shape == (1,) + array_size
-    assert np.array_equal(image_and_segmentation.images, array[None, ...])
+        image_and_segmentation = load_image_in_known_formats(dcm_file, load_segmentation=False)
+        assert image_and_segmentation.images.ndim == 3 and image_and_segmentation.images.shape == (1,) + array_size
+        assert np.array_equal(image_and_segmentation.images, array[None, ...])
 
 
 @pytest.mark.parametrize(["file_path", "expected_shape"],

--- a/Tests/ML/utils/test_io_util.py
+++ b/Tests/ML/utils/test_io_util.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from pathlib import Path
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, Callable
 from unittest import mock
 from skimage.transform import resize
 
@@ -204,16 +204,16 @@ def write_test_dicom(array: np.ndarray, path: Path) -> None:
     writer.Execute(image)
 
 
-def get_mock_function(monochrome2: bool, bits_stored: Optional[int] = None):
+def get_mock_function(monochrome2: bool, bits_stored: Optional[int] = None) -> Callable:
     """
     SimpleITK does not allow us to set Photometric Interpretation and Stored Bits, so we need to mock the reader to
     make sure the right attributes are returned.
     """
     get_metadata_function = sitk.ImageFileReader.GetMetaData
 
-    def mock_function(image_reader: sitk.ImageFileReader, key: str):
+    def mock_function(image_reader: sitk.ImageFileReader, key: str) -> str:
         if bits_stored and key == "0028|0101":
-            return bits_stored
+            return str(bits_stored)
         elif not monochrome2 and key == "0028|0004":
             return "MONOCHROME1"
         else:

--- a/Tests/ML/utils/test_io_util.py
+++ b/Tests/ML/utils/test_io_util.py
@@ -207,7 +207,9 @@ def write_test_dicom(array: np.ndarray, path: Path) -> None:
 def get_mock_function(monochrome2: bool, bits_stored: Optional[int] = None) -> Callable:
     """
     SimpleITK does not allow us to set the Photometric Interpretation and Stored Bits tags when writing the Dicom image.
-    For the tests, if an image should set these tags we wrap the reader to return the right attributes.
+    In these tests, if the image should be MONOCHROME1 we write an inverted image with tag MONOCHROME2
+    and use this wrapper around the SimpleITK metadata reader to make it look to the test like the tag was MONOCHROME1.
+    Similarly, we write images with StoredBits set to 16, but use this wrapper to change StoredBits while reading.
     """
     get_metadata_function = sitk.ImageFileReader.GetMetaData
 

--- a/Tests/ML/utils/test_io_util.py
+++ b/Tests/ML/utils/test_io_util.py
@@ -19,7 +19,7 @@ from InnerEye.ML.utils import io_util
 from InnerEye.ML.utils.dataset_util import DatasetExample, store_and_upload_example
 from InnerEye.ML.utils.io_util import ImageHeader, is_nifti_file_path, is_numpy_file_path, \
     load_image_in_known_formats, load_numpy_image, is_dicom_file_path, load_dicom_image, \
-    ImageAndSegmentations, load_images_and_stack
+    ImageAndSegmentations, load_images_and_stack, DicomTags, PhotometricInterpretation
 from Tests.ML.util import assert_file_contents
 from Tests.fixed_paths_for_tests import full_ml_test_data_path
 
@@ -214,10 +214,10 @@ def get_mock_function(is_monochrome2: bool, bits_stored: Optional[int] = None) -
     get_metadata_function = sitk.ImageFileReader.GetMetaData
 
     def mock_function(image_reader: sitk.ImageFileReader, key: str) -> str:
-        if bits_stored and key == "0028|0101":
+        if bits_stored and key == DicomTags.BitsStored.value:
             return str(bits_stored)
-        elif not is_monochrome2 and key == "0028|0004":
-            return "MONOCHROME1"
+        elif not is_monochrome2 and key == DicomTags.PhotometricInterpretation.value:
+            return PhotometricInterpretation.MONOCHROME1.value
         else:
             return get_metadata_function(image_reader, key)
 

--- a/Tests/ML/utils/test_io_util.py
+++ b/Tests/ML/utils/test_io_util.py
@@ -206,8 +206,8 @@ def write_test_dicom(array: np.ndarray, path: Path) -> None:
 
 def get_mock_function(monochrome2: bool, bits_stored: Optional[int] = None) -> Callable:
     """
-    SimpleITK does not allow us to set Photometric Interpretation and Stored Bits, so we need to mock the reader to
-    make sure the right attributes are returned.
+    SimpleITK does not allow us to set the Photometric Interpretation and Stored Bits tags when writing the Dicom image.
+    For the tests, if an image should set these tags we wrap the reader to return the right attributes.
     """
     get_metadata_function = sitk.ImageFileReader.GetMetaData
 


### PR DESCRIPTION
Read Dicom images with Photometric Interpretation set to "MONOCHROME1" correctly.