### PR TITLE
Remove Index column from segmentation report, print worst patients

### DIFF
--- a/InnerEye/ML/reports/segmentation_report.ipynb
+++ b/InnerEye/ML/reports/segmentation_report.ipynb
@@ -22,7 +22,9 @@
     "test_metrics_csv = innereye_path / 'Tests' / 'ML' / 'reports' / 'metrics_hn.csv'\n",
     "\n",
     "# The standard deviation range data points must fall outside of to be considered as outliers\n",
-    "outlier_range = 3.0"
+    "outlier_range = 3.0\n",
+    "# The maximum number of results to show when printing the low performing subjects\n",
+    "max_worst_patients = 20"
    ]
   },
   {
@@ -70,7 +72,7 @@
    "outputs": [],
    "source": [
     "if Path(test_metrics_csv).is_file():\n",
-    "    plot_scores_for_csv(test_metrics_csv, outlier_range)"
+    "    plot_scores_for_csv(test_metrics_csv, outlier_range, max_worst_patients)"
    ]
   },
   {
@@ -91,7 +93,7 @@
    "outputs": [],
    "source": [
     "if Path(val_metrics_csv).is_file():\n",
-    "    plot_scores_for_csv(val_metrics_csv, outlier_range)"
+    "    plot_scores_for_csv(val_metrics_csv, outlier_range, max_worst_patients)"
    ]
   },
   {
@@ -116,7 +118,7 @@
    "outputs": [],
    "source": [
     "if Path(train_metrics_csv).is_file():\n",
-    "    plot_scores_for_csv(train_metrics_csv, outlier_range)"
+    "    plot_scores_for_csv(train_metrics_csv, outlier_range, max_worst_patients)"
    ]
   },
   {

--- a/InnerEye/ML/reports/segmentation_report.py
+++ b/InnerEye/ML/reports/segmentation_report.py
@@ -5,15 +5,15 @@
 
 import matplotlib.pyplot as plt
 import pandas as pd
-from IPython.display import display
+from IPython.display import HTML, display
 from pandas import DataFrame
 
 from InnerEye.ML.reports.notebook_report import print_header
-from InnerEye.ML.utils.csv_util import OutlierType, extract_outliers
+from InnerEye.ML.utils.csv_util import OutlierType, mark_outliers
 from InnerEye.ML.utils.metrics_constants import MetricsFileColumns
 
 
-def plot_scores_for_csv(path_csv: str, outlier_range: float) -> None:
+def plot_scores_for_csv(path_csv: str, outlier_range: float, max_row_count: int) -> None:
     """
     Displays all the tables and figures given a csv file with segmentation metrics
     Columns expected: Patient,Structure,Dice,HausdorffDistance_mm,MeanDistance_mm
@@ -21,14 +21,29 @@ def plot_scores_for_csv(path_csv: str, outlier_range: float) -> None:
     print(f"Reading raw metrics data from: {path_csv}")
     df = pd.read_csv(path_csv)
     with pd.option_context('display.max_rows', None, 'display.max_columns', None, 'display.width', 150):
-        display_metric(df, MetricsFileColumns.Dice.value, outlier_range, high_values_are_good=True)
-        display_metric(df, MetricsFileColumns.HausdorffDistanceMM.value, outlier_range, high_values_are_good=False)
-        display_metric(df, MetricsFileColumns.MeanDistanceMM.value, outlier_range, high_values_are_good=False)
+        display_metric(df, MetricsFileColumns.Dice.value, outlier_range, max_row_count, high_values_are_good=True)
+        display_metric(df, MetricsFileColumns.HausdorffDistanceMM.value, outlier_range, max_row_count,
+                       high_values_are_good=False)
+        display_metric(df, MetricsFileColumns.MeanDistanceMM.value, outlier_range, max_row_count,
+                       high_values_are_good=False)
 
 
-def display_metric(df: pd.DataFrame, metric_name: str, outlier_range: float, high_values_are_good: bool) -> None:
+def display_without_index(df: pd.DataFrame) -> None:
+    """
+    Prints the given dataframe as HTML via the `display` function, but without the index column.
+    :param df: The dataframe to print.
+    """
+    display(HTML(df.to_html(index=False)))
+
+
+def display_metric(df: pd.DataFrame,
+                   metric_name: str,
+                   outlier_range: float,
+                   max_row_count: int,
+                   high_values_are_good: bool) -> None:
     """
     Displays a dataframe with a metric per structure, first showing the
+    :param max_row_count: The number of rows to print when showing the lowest score patients
     :param df: The dataframe with metrics per structure
     :param metric_name: The metric to sort by.
     :param outlier_range: The standard deviation range data points must fall outside of to be considered an outlier
@@ -37,22 +52,35 @@ def display_metric(df: pd.DataFrame, metric_name: str, outlier_range: float, hig
     """
     print_header(metric_name, level=2)
     # Display with best structures first.
-    display(describe_score(df, metric_name, ascending=(not high_values_are_good)))
-    print_header(f"Worst patients by {metric_name} (< {outlier_range} sd)", level=3)
-    display(display_outliers(df, outlier_range, metric_name, high_values_are_good))
+    display_without_index(describe_score(df, metric_name, ascending=(not high_values_are_good)))
+    print_header(f"{max_row_count} worst patients by {metric_name}", level=3)
+    print(f"Rows are marked as outliers if {metric_name} is more than {outlier_range} standard deviations from "
+          f"the mean.")
+    display_without_index(worst_patients_and_outliers(df, outlier_range, metric_name, high_values_are_good,
+                                                      max_row_count=max_row_count))
     boxplot_per_structure(df, column_name=metric_name, title=metric_name)
     plt.show()
 
 
-def display_outliers(df: pd.DataFrame, outlier_range: float,
-                     metric_name: str, high_values_are_good: bool) -> pd.DataFrame:
+def worst_patients_and_outliers(df: pd.DataFrame,
+                                outlier_range: float,
+                                metric_name: str,
+                                high_values_are_good: bool,
+                                max_row_count: int) -> pd.DataFrame:
     """
-    Prints a dataframe that contains the worst patients by the given metric.
-    "Worst" is determined by having a metric value which is less than the outlier_range
-    standard deviation from the mean.
+    Prints a dataframe that contains the worst patients by the given metric, and a column indicating whether the
+    performance is so poor that it is considered an outlier: metric value which is outside of
+    outlier_range * standard deviation from the mean.
+    :param df: The dataframe with metrics.
+    :param outlier_range: The multiplier for standard deviation when constructing the interval for outliers.
+    :param metric_name: The metric for which the "worst" patients should be computed.
+    :param high_values_are_good: If True, high values for the metric are considered good, and hence low values
+    are marked as outliers. If False, low values are considered good, and high values are marked as outliers.
+    :param max_row_count: The maximum number of rows to print.
+    :return:
     """
-    return extract_outliers(df, outlier_range, metric_name,
-                            OutlierType.LOW if high_values_are_good else OutlierType.HIGH)
+    marked = mark_outliers(df, outlier_range, metric_name, high_values_are_good)
+    return marked.sort_values(by=metric_name, ascending=high_values_are_good).head(max_row_count)
 
 
 def describe_score(df: pd.DataFrame, metric_name: str, ascending: bool = True) -> pd.DataFrame:

--- a/InnerEye/ML/reports/segmentation_report.py
+++ b/InnerEye/ML/reports/segmentation_report.py
@@ -9,7 +9,7 @@ from IPython.display import HTML, display
 from pandas import DataFrame
 
 from InnerEye.ML.reports.notebook_report import print_header
-from InnerEye.ML.utils.csv_util import OutlierType, mark_outliers
+from InnerEye.ML.utils.csv_util import mark_outliers
 from InnerEye.ML.utils.metrics_constants import MetricsFileColumns
 
 

--- a/Tests/ML/reports/test_segmentation_report.py
+++ b/Tests/ML/reports/test_segmentation_report.py
@@ -73,4 +73,3 @@ F,200"""
                                         max_row_count=2)
     assert worst["Patient"].to_list() == ["F", "E"]
     assert worst[COL_IS_OUTLIER].to_list() == ["Yes", ""]
-

--- a/Tests/ML/reports/test_segmentation_report.py
+++ b/Tests/ML/reports/test_segmentation_report.py
@@ -9,7 +9,8 @@ import pandas as pd
 
 from InnerEye.Common.output_directories import TestOutputDirectories
 from InnerEye.ML.reports.notebook_report import generate_segmentation_notebook
-from InnerEye.ML.reports.segmentation_report import describe_score
+from InnerEye.ML.reports.segmentation_report import describe_score, worst_patients_and_outliers
+from InnerEye.ML.utils.csv_util import COL_IS_OUTLIER
 from InnerEye.ML.utils.metrics_constants import MetricsFileColumns
 
 
@@ -51,3 +52,25 @@ def test_describe_metric() -> None:
 """
     with pd.option_context('display.max_rows', None, 'display.max_columns', None, 'display.width', 150):
         assert str(df2).splitlines() == expected.splitlines()
+
+
+def test_worst_patients() -> None:
+    data = """Patient,foo
+A,0
+C,100
+D,101
+E,102
+F,200"""
+    df = pd.read_csv(StringIO(data))
+    assert df["foo"].std() < 80
+    # Metric values are constructed such that A and F are more than 1 std away from the mean. With outlier_range
+    # set to 1, we should get A and F back as outliers.
+    worst = worst_patients_and_outliers(df, outlier_range=1, metric_name="foo", high_values_are_good=True,
+                                        max_row_count=2)
+    assert worst["Patient"].to_list() == ["A", "C"]
+    assert worst[COL_IS_OUTLIER].to_list() == ["Yes", ""]
+    worst = worst_patients_and_outliers(df, outlier_range=1, metric_name="foo", high_values_are_good=False,
+                                        max_row_count=2)
+    assert worst["Patient"].to_list() == ["F", "E"]
+    assert worst[COL_IS_OUTLIER].to_list() == ["Yes", ""]
+

--- a/Tests/ML/utils/test_csv_util.py
+++ b/Tests/ML/utils/test_csv_util.py
@@ -90,9 +90,9 @@ def test_mark_outliers() -> None:
     df = pd.DataFrame({
         "foo": range(10)
     })
-    marked1 = mark_outliers(df, 1, "foo", outlier_type=OutlierType.LOW)
+    marked1 = mark_outliers(df, 1, "foo", high_values_are_good=True)
     assert COL_IS_OUTLIER in marked1
     assert marked1[COL_IS_OUTLIER].to_list() == ["Yes"] * 2 + [""] * 8
-    marked2 = mark_outliers(df, 1, "foo", outlier_type=OutlierType.HIGH)
+    marked2 = mark_outliers(df, 1, "foo", high_values_are_good=False)
     assert COL_IS_OUTLIER in marked2
     assert marked2[COL_IS_OUTLIER].to_list() == [""] * 8 + ["Yes"] * 2

--- a/Tests/ML/utils/test_csv_util.py
+++ b/Tests/ML/utils/test_csv_util.py
@@ -7,8 +7,9 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from InnerEye.ML.utils.csv_util import CSV_DATE_HEADER, CSV_FEATURE_HEADER, CSV_PATH_HEADER, CSV_SUBJECT_HEADER, \
-    OutlierType, drop_rows_missing_important_values, extract_outliers, load_csv
+from InnerEye.ML.utils.csv_util import COL_IS_OUTLIER, CSV_DATE_HEADER, CSV_FEATURE_HEADER, CSV_PATH_HEADER, \
+    CSV_SUBJECT_HEADER, \
+    OutlierType, drop_rows_missing_important_values, extract_outliers, load_csv, mark_outliers
 from Tests.fixed_paths_for_tests import full_ml_test_data_path
 
 known_csv_path = full_ml_test_data_path("hdf5_data") / "dataset.csv"
@@ -83,3 +84,15 @@ def test_extract_outliers_higher() -> None:
     assert list(range(8, 10, 1)) == list(extract_outliers(test_df, 1, "Hausdorff",
                                                           outlier_type=OutlierType.HIGH).Hausdorff.values)
     assert list() == list(extract_outliers(test_df, 2, "Hausdorff", outlier_type=OutlierType.HIGH).Hausdorff.values)
+
+
+def test_mark_outliers() -> None:
+    df = pd.DataFrame({
+        "foo": range(10)
+    })
+    marked1 = mark_outliers(df, 1, "foo", outlier_type=OutlierType.LOW)
+    assert COL_IS_OUTLIER in marked1
+    assert marked1[COL_IS_OUTLIER].to_list() == ["Yes"] * 2 + [""] * 8
+    marked2 = mark_outliers(df, 1, "foo", outlier_type=OutlierType.HIGH)
+    assert COL_IS_OUTLIER in marked2
+    assert marked2[COL_IS_OUTLIER].to_list() == [""] * 8 + ["Yes"] * 2


### PR DESCRIPTION
- Remove the confusing index column from the report
- Re-add worst patients by metrics, and merge that with outlier reports. 