### PR TITLE
Ensure that PR builds fail on any job errors, fix component governance

### DIFF
--- a/InnerEye/Azure/azure_util.py
+++ b/InnerEye/Azure/azure_util.py
@@ -10,8 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import conda_merge
-import ruamel
-import yaml
+import ruamel.yaml
 from azureml.core import Experiment, Run, Workspace, get_run
 from azureml.core._serialization_utils import _serialize_to_dict
 from azureml.core.conda_dependencies import CondaDependencies
@@ -344,7 +343,7 @@ def merge_conda_files(files: List[Path], result_file: Path) -> None:
     if deps:
         unified_definition[DEPENDENCIES] = deps
     with result_file.open("w") as f:
-        yaml.dump(unified_definition, f, indent=2, default_flow_style=False)
+        ruamel.yaml.dump(unified_definition, f, indent=2, default_flow_style=False)
 
 
 def merge_conda_dependencies(files: List[Path]) -> CondaDependencies:

--- a/InnerEye/Azure/secrets_handling.py
+++ b/InnerEye/Azure/secrets_handling.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Optional, cast, List
 
-import yaml
+import ruamel.yaml
 
 from InnerEye.Common import fixed_paths
 
@@ -143,7 +143,8 @@ def read_settings_yaml_file(yaml_file: Path) -> Dict[str, Any]:
     """
     if yaml_file is None:
         return dict()
-    yaml_contents = yaml.load(yaml_file.open('r'), Loader=yaml.Loader)
+
+    yaml_contents = ruamel.yaml.load(yaml_file.open('r'), Loader=ruamel.yaml.SafeLoader)
     v = "variables"
     if v in yaml_contents:
         if yaml_contents[v]:

--- a/InnerEye/Azure/tensorboard_monitor.py
+++ b/InnerEye/Azure/tensorboard_monitor.py
@@ -72,6 +72,7 @@ def monitor(monitor_config: AMLTensorBoardMonitorConfig, azure_config: AzureConf
             _msg = "No runs to monitor"
             if monitor_config.run_status:
                 _msg += f"with status [{monitor_config.run_status}]."
+            print(_msg)
             sys.exit(1)
 
     # Start TensorBoard on executing machine

--- a/InnerEye/ML/runner.py
+++ b/InnerEye/ML/runner.py
@@ -324,7 +324,6 @@ class Runner:
         if self.azure_config.azureml:
             run_object = self.submit_to_azureml()
         else:
-            raise ValueError("Expected to fail")
             self.run_in_situ()
         return self.model_config, run_object
 
@@ -362,7 +361,8 @@ class Runner:
         status = azure_run.get_status()
         # For PR builds where we wait for job completion, the job must have ended in a COMPLETED state.
         if self.azure_config.wait_for_completion and status != RunStatus.COMPLETED:
-            raise ValueError(f"Job {azure_run} completed with status {status}.")
+            raise ValueError(f"Run {azure_run.id} in experiment {azure_run.experiment.name} completed with "
+                             f"status {status}.")
         return azure_run
 
     def run_in_situ(self) -> None:

--- a/InnerEye/ML/runner.py
+++ b/InnerEye/ML/runner.py
@@ -324,6 +324,7 @@ class Runner:
         if self.azure_config.azureml:
             run_object = self.submit_to_azureml()
         else:
+            raise ValueError("Expected to fail")
             self.run_in_situ()
         return self.model_config, run_object
 
@@ -363,7 +364,7 @@ class Runner:
         # If a pytest failed, the runner has exited with code -1 (see below)
         if self.azure_config.wait_for_completion and status != RunStatus.COMPLETED:
             logging.error(f"Job completed with status {status}. Exiting.")
-            sys.exit(1)
+            exit(-1)
         return azure_run
 
     def run_in_situ(self) -> None:

--- a/InnerEye/ML/runner.py
+++ b/InnerEye/ML/runner.py
@@ -363,8 +363,7 @@ class Runner:
         # For PR builds where we wait for job completion, the job must have ended in a COMPLETED state.
         # If a pytest failed, the runner has exited with code -1 (see below)
         if self.azure_config.wait_for_completion and status != RunStatus.COMPLETED:
-            logging.error(f"Job completed with status {status}. Exiting.")
-            sys.exit(1)
+            raise ValueError(f"Job {azure_run} completed with status {status}.")
         return azure_run
 
     def run_in_situ(self) -> None:

--- a/InnerEye/ML/runner.py
+++ b/InnerEye/ML/runner.py
@@ -363,6 +363,7 @@ class Runner:
         # For PR builds where we wait for job completion, the job must have ended in a COMPLETED state.
         # If a pytest failed, the runner has exited with code -1 (see below)
         if self.azure_config.wait_for_completion and status != RunStatus.COMPLETED:
+            sys.exit(1)
             raise ValueError(f"Job {azure_run} completed with status {status}.")
         return azure_run
 

--- a/InnerEye/ML/runner.py
+++ b/InnerEye/ML/runner.py
@@ -364,7 +364,7 @@ class Runner:
         # If a pytest failed, the runner has exited with code -1 (see below)
         if self.azure_config.wait_for_completion and status != RunStatus.COMPLETED:
             logging.error(f"Job completed with status {status}. Exiting.")
-            sys.exit(-1)
+            sys.exit(1)
         return azure_run
 
     def run_in_situ(self) -> None:

--- a/InnerEye/ML/runner.py
+++ b/InnerEye/ML/runner.py
@@ -364,7 +364,7 @@ class Runner:
         # If a pytest failed, the runner has exited with code -1 (see below)
         if self.azure_config.wait_for_completion and status != RunStatus.COMPLETED:
             logging.error(f"Job completed with status {status}. Exiting.")
-            exit(-1)
+            sys.exit(-1)
         return azure_run
 
     def run_in_situ(self) -> None:

--- a/azure-pipelines/build.yaml
+++ b/azure-pipelines/build.yaml
@@ -17,8 +17,11 @@ steps:
   - bash: |
       conda env create --file environment.yml --name InnerEye --quiet
       source activate InnerEye
-      echo "Environment has been created with these packages:"
-      pip freeze
+      echo Storing environment for later use by ComponentGovernance
+      # This file is picked up later by ComponentGovernance
+      pip freeze > requirements.txt
+      echo Environment has been created with these packages:
+      cat requirements.txt
     failOnStderr: false # Conda env create does not have an option to suppress warnings generated in wheel.py
     condition: succeeded()
     displayName: Create conda environment

--- a/azure-pipelines/build.yaml
+++ b/azure-pipelines/build.yaml
@@ -39,7 +39,7 @@ steps:
       source activate InnerEye
       flake8
     failOnStderr: true
-    condition: succeeded()
+    condition: succeededOrFailed()
     displayName: flake8
 
   - bash: |
@@ -55,6 +55,7 @@ steps:
       sed -i -e "s/subscription_id: ''/subscription_id: '$(InnerEyeDevSubscriptionID)'/" InnerEye/settings.yml
       sed -i -e "s/application_id: ''/application_id: '$(InnerEyeDeepLearningServicePrincipalID)'/" InnerEye/settings.yml
     displayName: Store subscription in settings.yml
+    condition: succeededOrFailed()
 
   # Install the InnerEye package without its dependencies. We have already create an environment that has everything
   # the package needs. If --no-deps is omitted, this causes a weird package conflict with azure-storage-blob
@@ -64,7 +65,7 @@ steps:
     env:
       IS_DEV_PACKAGE: True
     failOnStderr: false
-    condition: succeeded()
+    condition: succeededOrFailed()
     displayName: Install InnerEye (Dev) Package
 
   # First run all tests that require the InnerEye package. All code should be consumed via the InnerEye package,

--- a/azure-pipelines/train_template.yml
+++ b/azure-pipelines/train_template.yml
@@ -2,13 +2,13 @@ steps:
   - template: azure_runner_env.yml
 
   - bash: |
+      set -e  # This makes the script fail if any command in it fails, not just the last one
       source activate AzureRunner
       branch_prefix="refs/heads/"
       full_branch_name=$(Build.SourceBranch)
       branch_name_without_prefix=${full_branch_name#$branch_prefix}
       source_version_message="`echo $(Build.SourceVersionMessage) | tr -dc 'A-Za-z0-9_ ' | cut -c1-120`"
       python ./InnerEye/ML/runner.py --azureml=True --model="$(model)" --train="$(train)" $(more_switches) --number_of_cross_validation_splits="$(number_of_cross_validation_splits)" --wait_for_completion="${{parameters.wait_for_completion}}" --max_run_duration="${{parameters.max_run_duration}}" --pytest_mark="${{parameters.pytest_mark}}" --cluster="$(cluster)" --run_recovery_id="$(run_recovery_id)" --tag="$(tag)" --build_number=$(Build.BuildId) --build_user="$(Build.RequestedFor)" --build_user_email="" --build_branch="$branch_name_without_prefix" --build_source_id="$(Build.SourceVersion)" --build_source_message="$source_version_message" --build_source_author="$(Build.SourceVersionAuthor)" --build_source_repository="$(Build.Repository.Name)"
-      echo $?
     env:
       PYTHONPATH: $(Build.SourcesDirectory)/
       APPLICATION_KEY: $(InnerEyeDeepLearningServicePrincipalKey)

--- a/azure-pipelines/train_template.yml
+++ b/azure-pipelines/train_template.yml
@@ -8,6 +8,7 @@ steps:
       branch_name_without_prefix=${full_branch_name#$branch_prefix}
       source_version_message="`echo $(Build.SourceVersionMessage) | tr -dc 'A-Za-z0-9_ ' | cut -c1-120`"
       python ./InnerEye/ML/runner.py --azureml=True --model="$(model)" --train="$(train)" $(more_switches) --number_of_cross_validation_splits="$(number_of_cross_validation_splits)" --wait_for_completion="${{parameters.wait_for_completion}}" --max_run_duration="${{parameters.max_run_duration}}" --pytest_mark="${{parameters.pytest_mark}}" --cluster="$(cluster)" --run_recovery_id="$(run_recovery_id)" --tag="$(tag)" --build_number=$(Build.BuildId) --build_user="$(Build.RequestedFor)" --build_user_email="" --build_branch="$branch_name_without_prefix" --build_source_id="$(Build.SourceVersion)" --build_source_message="$source_version_message" --build_source_author="$(Build.SourceVersionAuthor)" --build_source_repository="$(Build.Repository.Name)"
+      echo $?
     env:
       PYTHONPATH: $(Build.SourcesDirectory)/
       APPLICATION_KEY: $(InnerEyeDeepLearningServicePrincipalKey)

--- a/azure-pipelines/train_via_submodule.yml
+++ b/azure-pipelines/train_via_submodule.yml
@@ -6,6 +6,7 @@ steps:
   # After the end of this step, most_recent_run.txt will contain the run recovery ID of the training run, not
   # the recovery run.
   - bash: |
+      set -e
       source activate AzureRunner
       mkdir $(Agent.TempDirectory)/InnerEye/
       cp -r $(Build.SourcesDirectory)/TestSubmodule $(Agent.TempDirectory)/InnerEye/TestSubmodule

--- a/azure-pipelines/train_via_submodule.yml
+++ b/azure-pipelines/train_via_submodule.yml
@@ -6,7 +6,7 @@ steps:
   # After the end of this step, most_recent_run.txt will contain the run recovery ID of the training run, not
   # the recovery run.
   - bash: |
-      set -e
+      set -e  # This makes the script fail if any command in it fails, not just the last one
       source activate AzureRunner
       mkdir $(Agent.TempDirectory)/InnerEye/
       cp -r $(Build.SourcesDirectory)/TestSubmodule $(Agent.TempDirectory)/InnerEye/TestSubmodule

--- a/environment.yml
+++ b/environment.yml
@@ -52,4 +52,3 @@ dependencies:
       - tensorboard==2.3.0
       - tensorboardX==2.1
       - torchprof==1.1.1
-

--- a/environment.yml
+++ b/environment.yml
@@ -30,12 +30,11 @@ dependencies:
       - mypy-extensions==0.4.3
       - numpy==1.19.1
       - pandas==1.1.0
-      - papermill==2.1.2
+      - papermill==2.2.2
       - param==1.9.3
       - pillow==7.2.0
       - psutil==5.7.2
       - pyflakes==2.2.0
-      - PyYAML==5.3.1
       - pytest==6.0.1
       - pytest-cov==2.10.1
       - pytest-forked==1.3.0


### PR DESCRIPTION
- The "TrainViaSubmodule" step presently only fails if the last python call fails. Fix that.
- Component Governance was accidentally disabled in #290 