### PR TITLE
Implement grouped dataset splits and cross-validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ created.
 
 ### Added
 - New extensions of SegmentationModelBases `HeadAndNeckBase` and `ProstateBase`. Use these classes to build your own Head&Neck or Prostate models, by just providing a list of foreground classes.
+- Grouped dataset splits and k-fold cross-validation. This allows, for example, training on datasets with multiple images per subject without leaking data from the same subject across train/test/validation sets or cross-validation folds.
 
 ### Changed
 - The arguments of the `score.py` script changed: `data_root` -> `data_folder`, it no longer assumes a fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ created.
 
 ### Added
 - New extensions of SegmentationModelBases `HeadAndNeckBase` and `ProstateBase`. Use these classes to build your own Head&Neck or Prostate models, by just providing a list of foreground classes.
-- Grouped dataset splits and k-fold cross-validation. This allows, for example, training on datasets with multiple images per subject without leaking data from the same subject across train/test/validation sets or cross-validation folds.
+- Grouped dataset splits and k-fold cross-validation. This allows, for example, training on datasets with multiple images per subject without leaking data from the same subject across train/test/validation sets or cross-validation folds. To use this functionality, simply provide the name of the CSV grouping column (`group_column`) when creating the `DatasetSplits` object in your model config's `get_model_train_test_dataset_splits()` method. See the `InnerEye.ML.utils.split_dataset.DatasetSplits` class for details.
 
 ### Changed
 - The arguments of the `score.py` script changed: `data_root` -> `data_folder`, it no longer assumes a fixed

--- a/InnerEye/ML/utils/split_dataset.py
+++ b/InnerEye/ML/utils/split_dataset.py
@@ -30,9 +30,18 @@ class DatasetSplits:
 
     def __post_init__(self) -> None:
         common_util.check_properties_are_not_none(self)
+
+        def pairwise_intersection(*collections):
+            """Returns any element that appears in more than one collection."""
+            from itertools import combinations
+            intersection = set()
+            for col1, col2 in combinations(map(set, collections), 2):
+                intersection |= col1 & col2
+            return intersection
+
         # perform dataset split validity assertions
         unique_train, unique_test, unique_val = self.unique_subjects()
-        intersection = set.intersection(set(unique_train), set(unique_test), set(unique_val))
+        intersection = pairwise_intersection(unique_train, unique_test, unique_val)
 
         if len(intersection) != 0:
             raise ValueError("Train, Test, and Val splits must have no intersection, found: {}".format(intersection))

--- a/InnerEye/ML/utils/split_dataset.py
+++ b/InnerEye/ML/utils/split_dataset.py
@@ -272,7 +272,8 @@ class DatasetSplits:
                          train_ids: Sequence[str],
                          test_ids: Sequence[str],
                          val_ids: Sequence[str],
-                         subject_column: str = CSV_SUBJECT_HEADER) -> DatasetSplits:
+                         subject_column: str = CSV_SUBJECT_HEADER,
+                         group_column: str = None) -> DatasetSplits:
         """
         Assuming a DataFrame with columns subject
         Takes a slice of values from each data split train/test/val for the provided ids.
@@ -282,14 +283,12 @@ class DatasetSplits:
         :param test_ids: ids for testing.
         :param val_ids: ids for validation.
         :param subject_column: subject id column name
+        :param group_column: grouping column name; if given, samples from each group will always be
+            in the same subset (train, val, or test) and cross-validation fold.
         :return: Data splits with respected dataset split ids.
         """
-        return DatasetSplits(
-            train=DatasetSplits.get_df_from_ids(df, train_ids, subject_column),
-            test=DatasetSplits.get_df_from_ids(df, test_ids, subject_column),
-            val=DatasetSplits.get_df_from_ids(df, val_ids, subject_column),
-            subject_column=subject_column
-        )
+        return DatasetSplits._from_split_keys(df, train_ids, test_ids, val_ids, key_column=subject_column,
+                                              subject_column=subject_column, group_column=group_column)
 
     @staticmethod
     def from_institutions(df: pd.DataFrame,

--- a/InnerEye/ML/utils/split_dataset.py
+++ b/InnerEye/ML/utils/split_dataset.py
@@ -8,6 +8,7 @@ import logging
 import random
 import sys
 from dataclasses import dataclass
+from itertools import combinations
 from math import ceil
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
@@ -34,7 +35,6 @@ class DatasetSplits:
 
         def pairwise_intersection(*collections: Iterable) -> Set:
             """Returns any element that appears in more than one collection."""
-            from itertools import combinations
             intersection = set()
             for col1, col2 in combinations(map(set, collections), 2):
                 intersection |= col1 & col2

--- a/InnerEye/ML/utils/split_dataset.py
+++ b/InnerEye/ML/utils/split_dataset.py
@@ -32,7 +32,7 @@ class DatasetSplits:
     def __post_init__(self) -> None:
         common_util.check_properties_are_not_none(self)
 
-        def pairwise_intersection(*collections):
+        def pairwise_intersection(*collections: Iterable) -> Set:
             """Returns any element that appears in more than one collection."""
             from itertools import combinations
             intersection = set()
@@ -207,10 +207,10 @@ class DatasetSplits:
                          train_keys: Sequence[str],
                          test_keys: Sequence[str],
                          val_keys: Sequence[str],
+                         *,  # make column names keyword-only arguments to avoid mistakes when providing both
                          key_column: str,
                          subject_column: str,
-                         group_column: str
-                         ) -> DatasetSplits:
+                         group_column: Optional[str]) -> DatasetSplits:
         """
         Takes a slice of values from each data split train/test/val for the provided keys.
 
@@ -236,8 +236,9 @@ class DatasetSplits:
                          proportion_train: float,
                          proportion_test: float,
                          proportion_val: float,
+                         *,  # make column names keyword-only arguments to avoid mistakes when providing both
                          subject_column: str = CSV_SUBJECT_HEADER,
-                         group_column: str = None,
+                         group_column: Optional[str] = None,
                          shuffle: bool = True,
                          random_seed: int = 0) -> DatasetSplits:
         """
@@ -255,7 +256,7 @@ class DatasetSplits:
         :param random_seed: Random seed to be used for shuffle 0 is default.
         :return:
         """
-        key_column = subject_column if group_column is None else group_column
+        key_column: str = subject_column if group_column is None else group_column
         split_keys = df[key_column].unique()
         if shuffle:
             # fix the random seed so we can guarantee reproducibility when working with shuffle
@@ -279,8 +280,9 @@ class DatasetSplits:
                          train_ids: Sequence[str],
                          test_ids: Sequence[str],
                          val_ids: Sequence[str],
+                         *,  # make column names keyword-only arguments to avoid mistakes when providing both
                          subject_column: str = CSV_SUBJECT_HEADER,
-                         group_column: str = None) -> DatasetSplits:
+                         group_column: Optional[str] = None) -> DatasetSplits:
         """
         Assuming a DataFrame with columns subject
         Takes a slice of values from each data split train/test/val for the provided ids.
@@ -302,8 +304,9 @@ class DatasetSplits:
                     train_groups: Sequence[str],
                     test_groups: Sequence[str],
                     val_groups: Sequence[str],
-                    subject_column: str = CSV_SUBJECT_HEADER,
-                    group_column: str = None) -> DatasetSplits:
+                    *,  # make column names keyword-only arguments to avoid mistakes when providing both
+                    group_column: str,
+                    subject_column: str = CSV_SUBJECT_HEADER) -> DatasetSplits:
         """
         Assuming a DataFrame with columns subject
         Takes a slice of values from each data split train/test/val for the provided groups.

--- a/InnerEye/ML/utils/split_dataset.py
+++ b/InnerEye/ML/utils/split_dataset.py
@@ -291,6 +291,29 @@ class DatasetSplits:
                                               subject_column=subject_column, group_column=group_column)
 
     @staticmethod
+    def from_groups(df: pd.DataFrame,
+                    train_groups: Sequence[str],
+                    test_groups: Sequence[str],
+                    val_groups: Sequence[str],
+                    subject_column: str = CSV_SUBJECT_HEADER,
+                    group_column: str = None) -> DatasetSplits:
+        """
+        Assuming a DataFrame with columns subject
+        Takes a slice of values from each data split train/test/val for the provided groups.
+
+        :param df: the input DataFrame
+        :param train_groups: groups for training.
+        :param test_groups: groups for testing.
+        :param val_groups: groups for validation.
+        :param subject_column: subject id column name
+        :param group_column: grouping column name; if given, samples from each group will always be
+            in the same subset (train, val, or test) and cross-validation fold.
+        :return: Data splits with respected dataset split ids.
+        """
+        return DatasetSplits._from_split_keys(df, train_groups, test_groups, val_groups, key_column=group_column,
+                                              subject_column=subject_column, group_column=group_column)
+
+    @staticmethod
     def from_institutions(df: pd.DataFrame,
                           proportion_train: float,
                           proportion_test: float,

--- a/InnerEye/ML/utils/split_dataset.py
+++ b/InnerEye/ML/utils/split_dataset.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 import numpy as np
 import pandas as pd
-from sklearn.model_selection import KFold
+from sklearn.model_selection import GroupKFold, KFold
 
 from InnerEye.Common import common_util
 from InnerEye.ML.common import ModelExecutionMode
@@ -424,7 +424,12 @@ class DatasetSplits:
 
     def get_k_fold_cross_validation_splits(self, n_splits: int, random_seed: int = 0) -> List[DatasetSplits]:
         """
-        Creates K folds from the Train + Val splits
+        Creates K folds from the Train + Val splits.
+
+        If a group_column has been specified, the folds will be split such that
+        subjects in a group will not be separated. In this case, the splits are
+        fully deterministic, and random_seed is ignored.
+
         :param n_splits: number of folds to perform.
         :param random_seed: random seed to be used for shuffle 0 is default.
         :return: List of K dataset splits
@@ -432,17 +437,30 @@ class DatasetSplits:
         if n_splits <= 0:
             raise ValueError("n_splits must be >= 0 found {}".format(n_splits))
 
-        # calculate the random split indices
-        k_folds = KFold(n_splits=n_splits, shuffle=True, random_state=random_seed)
         # concatenate train and val, as training set = train + val
         cv_dataset = pd.concat([self.train, self.val])
-        # unique subjects
-        subject_ids = cv_dataset[self.subject_column].unique()
+
+        if self.group_column is None:  # perform standard subject-based k-fold cross-validation
+            # unique subjects
+            subject_ids = cv_dataset[self.subject_column].unique()
+            # calculate the random split indices
+            k_folds = KFold(n_splits=n_splits, shuffle=True, random_state=random_seed)
+            folds_gen = k_folds.split(subject_ids)
+        else:  # perform grouped k-fold cross-validation
+            # Here we take all entries, rather than unique, to keep subjects
+            # matched to groups in the resulting arrays. This works, but could
+            # perhaps be improved with group-by logic...?
+            subject_ids = cv_dataset[self.subject_column].values
+            groups = cv_dataset[self.group_column].values
+            # scikit-learn uses a deterministic algorithm for grouped splits
+            # that tries to balance the group sizes in all folds
+            k_folds = GroupKFold(n_splits=n_splits)
+            folds_gen = k_folds.split(subject_ids, groups=groups)
+
         ids_from_indices = lambda indices: [subject_ids[x] for x in indices]
         # create the number of requested splits of the dataset
         return [
             DatasetSplits(train=self.get_df_from_ids(cv_dataset, ids_from_indices(train_indices), self.subject_column),
                           val=self.get_df_from_ids(cv_dataset, ids_from_indices(val_indices), self.subject_column),
-                          test=self.test,
-                          subject_column=self.subject_column) for train_indices, val_indices in
-            k_folds.split(subject_ids)]
+                          test=self.test, subject_column=self.subject_column, group_column=self.group_column)
+            for train_indices, val_indices in folds_gen]

--- a/InnerEye/ML/utils/split_dataset.py
+++ b/InnerEye/ML/utils/split_dataset.py
@@ -88,12 +88,16 @@ class DatasetSplits:
         """
         Creates a new dataset split that has at most the specified numbers of subjects in train, validation and test
         sets respectively.
+
+        If `group_column` was specified, this operation may violate the grouping constraints and the resulting splits
+        object will have `group_column == None`.
+
         :param restriction_pattern: a string containing zero or two commas, and otherwise digits or "+". An empty
-        substring will result in no restriction for the corresponding dataset. Thus "20,,3" means "restrict to 20
-        training images and 3 test images, with no restriction on validation". A "+" value means "reassign all
-        images from the set(s) with a numeric count (there must be at least one) to this set". Thus ",0,+" means "leave
-        the training set alone, but move all validation images to the test set", and "0,2,+" means "move
-        all training images and all but 2 validation images to the test set".
+            substring will result in no restriction for the corresponding dataset. Thus "20,,3" means "restrict to 20
+            training images and 3 test images, with no restriction on validation". A "+" value means "reassign all
+            images from the set(s) with a numeric count (there must be at least one) to this set". Thus ",0,+" means
+            "leave the training set alone, but move all validation images to the test set", and "0,2,+" means "move
+            all training images and all but 2 validation images to the test set".
         :return: A new dataset split object with (at most) the numbers of subjects specified by restrict_pattern
         """
 
@@ -336,8 +340,11 @@ class DatasetSplits:
                           subject_ids_for_test_only: Optional[Iterable[str]] = None) -> DatasetSplits:
         """
         Assuming a DataFrame with columns subject and institutionId
+
         Takes a slice of values from each institution based on the train/test/val proportions provided,
         such that for each institution there is at least one subject in each of the train/test/val splits.
+
+        This method for creating `DatasetSplits` does not currently support grouping.
 
         :param df: the input DataFrame
         :param proportion_train: Proportion of images per institution to be used for training.
@@ -347,11 +354,11 @@ class DatasetSplits:
         :param shuffle: If True the subjects in the dataframe will be shuffle before performing splits.
         :param random_seed: Random seed to be used for shuffle 0 is default.
         :param exclude_institutions: If given, all subjects where institutionId has the given value will be
-        excluded from train, test, and validation set.
+            excluded from train, test, and validation set.
         :param institutions_for_test_only: If given, all subjects where institutionId has the given value will be
-        placed only in the test set.
+            placed only in the test set.
         :param subject_ids_for_test_only: If given, all images with the provided subject Ids will be placed in the
-        test set.
+            test set.
         :return: Data splits with respected dataset split proportions per institution.
         """
         results: Dict[ModelExecutionMode, pd.DataFrame] = {}

--- a/InnerEye/ML/utils/split_dataset.py
+++ b/InnerEye/ML/utils/split_dataset.py
@@ -26,6 +26,7 @@ class DatasetSplits:
     val: pd.DataFrame
     test: pd.DataFrame
     subject_column: str = CSV_SUBJECT_HEADER
+    group_column: Optional[str] = None
     allow_empty: bool = False
 
     def __post_init__(self) -> None:
@@ -45,6 +46,15 @@ class DatasetSplits:
 
         if len(intersection) != 0:
             raise ValueError("Train, Test, and Val splits must have no intersection, found: {}".format(intersection))
+
+        if self.group_column is not None:
+            groups_train = self.train[self.group_column].unique()
+            groups_test = self.test[self.group_column].unique()
+            groups_val = self.val[self.group_column].unique()
+            group_intersection = pairwise_intersection(groups_train, groups_test, groups_val)
+            if len(group_intersection) != 0:
+                raise ValueError("Train, Test, and Val splits must have no intersecting groups, found: {}"
+                                 .format(group_intersection))
 
         if (not self.allow_empty) and any([len(x) == 0 for x in [unique_train, unique_val]]):
             raise ValueError("train_ids({}), val_ids({}) must have at least one value"

--- a/InnerEye/ML/utils/split_dataset.py
+++ b/InnerEye/ML/utils/split_dataset.py
@@ -203,6 +203,35 @@ class DatasetSplits:
         return result
 
     @staticmethod
+    def _from_split_keys(df: pd.DataFrame,
+                         train_keys: Sequence[str],
+                         test_keys: Sequence[str],
+                         val_keys: Sequence[str],
+                         key_column: str,
+                         subject_column: str,
+                         group_column: str
+                         ) -> DatasetSplits:
+        """
+        Takes a slice of values from each data split train/test/val for the provided keys.
+
+        :param df: the input DataFrame
+        :param train_keys: keys for training.
+        :param test_keys: keys for testing.
+        :param val_keys: keys for validation.
+        :param key_column: name of the column the provided keys belong to
+        :param subject_column: subject id column name
+        :param group_column: grouping column name; if given, samples from each group will always be
+            in the same subset (train, val, or test) and cross-validation fold.
+        :return: Data splits with respected dataset split ids.
+        """
+        train_df = DatasetSplits.get_df_from_ids(df, train_keys, key_column)
+        test_df = DatasetSplits.get_df_from_ids(df, test_keys, key_column)
+        val_df = DatasetSplits.get_df_from_ids(df, val_keys, key_column)
+
+        return DatasetSplits(train=train_df, test=test_df, val=val_df,
+                             subject_column=subject_column, group_column=group_column)
+
+    @staticmethod
     def from_proportions(df: pd.DataFrame,
                          proportion_train: float,
                          proportion_test: float,

--- a/Tests/ML/test_split_dataset.py
+++ b/Tests/ML/test_split_dataset.py
@@ -242,6 +242,8 @@ def _get_test_df() -> Tuple[DataFrame, List[str], List[str], List[str]]:
         CSV_GROUP_HEADER: [i // 5 for i in range(0, 100)],
         "other": list(range(0, 100))
     }
+    assert all(np.bincount(test_data[CSV_GROUP_HEADER]) > 1), "Found singleton groups"
+    assert len(np.unique(test_data[CSV_GROUP_HEADER])) > 1, "Found a single group"
     train_ids, test_ids, val_ids = list(range(0, 50)), list(range(50, 75)), list(range(75, 100))
     test_df = DataFrame(test_data, columns=list(test_data.keys()))
     return test_df, list(map(str, test_ids)), list(map(str, train_ids)), list(map(str, val_ids))

--- a/Tests/ML/test_split_dataset.py
+++ b/Tests/ML/test_split_dataset.py
@@ -4,7 +4,7 @@
 #  ------------------------------------------------------------------------------------------
 import random
 import sys
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 import numpy as np
 import pandas as pd
@@ -160,7 +160,7 @@ def test_get_k_fold_cross_validation_splits() -> None:
                  .difference(set(test_df.subject.unique()))) == 0 for x in folds])
 
 
-def _check_is_partition(total, parts, column):
+def _check_is_partition(total: pd.DataFrame, parts: Iterable[pd.DataFrame], column: str) -> None:
     """Asserts that `total` is the union of `parts`, and that the latter are pairwise disjoint"""
     if column is None:
         return
@@ -176,7 +176,8 @@ def _check_is_partition(total, parts, column):
 def test_grouped_splits(group_column: str) -> None:
     test_df = _get_test_df()[0]
     proportions = [0.5, 0.4, 0.1]
-    splits = DatasetSplits.from_proportions(test_df, *proportions, group_column=group_column)
+    splits = DatasetSplits.from_proportions(test_df, proportions[0], proportions[1], proportions[2],
+                                            group_column=group_column)
     _check_is_partition(test_df, [splits.train, splits.test, splits.val], CSV_SUBJECT_HEADER)
     _check_is_partition(test_df, [splits.train, splits.test, splits.val], group_column)
 
@@ -185,7 +186,8 @@ def test_grouped_splits(group_column: str) -> None:
 def test_grouped_k_fold_cross_validation_splits(group_column: str) -> None:
     test_df = _get_test_df()[0]
     proportions = [0.5, 0.4, 0.1]
-    splits = DatasetSplits.from_proportions(test_df, *proportions, group_column=group_column)
+    splits = DatasetSplits.from_proportions(test_df, proportions[0], proportions[1], proportions[2],
+                                            group_column=group_column)
 
     n_splits = 7  # mutually prime with numbers of subjects and groups
     val_folds = []

--- a/Tests/ML/test_split_dataset.py
+++ b/Tests/ML/test_split_dataset.py
@@ -4,6 +4,7 @@
 #  ------------------------------------------------------------------------------------------
 import random
 import sys
+from itertools import combinations
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 import numpy as np
@@ -164,7 +165,6 @@ def _check_is_partition(total: pd.DataFrame, parts: Iterable[pd.DataFrame], colu
     """Asserts that `total` is the union of `parts`, and that the latter are pairwise disjoint"""
     if column is None:
         return
-    from itertools import combinations
     total = set(total[column].unique())
     parts = [set(part[column].unique()) for part in parts]
     assert total == set.union(*parts)

--- a/Tests/ML/test_split_dataset.py
+++ b/Tests/ML/test_split_dataset.py
@@ -128,7 +128,7 @@ def test_split_by_subject_ids_invalid(splits: List[List[str]]) -> None:
 
 def test_get_subject_ranges_for_splits() -> None:
     def _check_at_least_one(x: Dict[ModelExecutionMode, Set[str]]) -> None:
-        assert all([len(x[mode]) >= 1] for mode in x.keys())
+        assert all(len(x[mode]) >= 1 for mode in x.keys())
 
     proportions = [0.5, 0.4, 0.1]
 


### PR DESCRIPTION
This PR adds the ability to specify a `group_column` in addition to the primary `subject_column` when creating `DatasetSplits`. If given, this ensures that subjects within each group cannot be in separate training/test/validation sets or cross-validation folds.