### PR TITLE
Draft: Workaround for CUDA initialization error

### DIFF
--- a/InnerEye/ML/model_testing.py
+++ b/InnerEye/ML/model_testing.py
@@ -177,6 +177,7 @@ def segmentation_model_test_epoch(config: SegmentationModelBase,
                                 results_folder=results_folder,
                                 image_header=sample.metadata.image_header)
     # Evaluate model generated segmentation maps.
+    config.use_gpu = False
     num_workers = min(cpu_count(), len(ds))
     with Pool(processes=num_workers) as pool:
         pool_outputs = pool.map(


### PR DESCRIPTION
Potential workaround for #395: Ensure that the evaluation loop (where we only consume the GPU results) works on CPU only.