### PR TITLE
Replace binary_cross_entropy with binary_cross_entropy_with_logits

### DIFF
--- a/InnerEye/ML/lightning_metrics.py
+++ b/InnerEye/ML/lightning_metrics.py
@@ -119,11 +119,12 @@ class ScalarMetricsBase(Metric):
     and labels (field `targets`). Derived classes need to override the `compute` method.
     """
 
-    def __init__(self, name: str = ""):
+    def __init__(self, name: str = "", compute_from_logits: bool = False):
         super().__init__(dist_sync_on_step=False)
         self.add_state("preds", default=[], dist_reduce_fx=None)
         self.add_state("targets", default=[], dist_reduce_fx=None)
         self.name = name
+        self.compute_from_logits = compute_from_logits
 
     def update(self, preds: torch.Tensor, targets: torch.Tensor) -> None:  # type: ignore
         self.preds.append(preds)  # type: ignore
@@ -254,7 +255,7 @@ class BinaryCrossEntropyWithLogits(ScalarMetricsBase):
     """
 
     def __init__(self) -> None:
-        super().__init__(name=MetricType.CROSS_ENTROPY.value)
+        super().__init__(name=MetricType.CROSS_ENTROPY.value, compute_from_logits=True)
 
     def compute(self) -> torch.Tensor:
         preds, targets = self._get_preds_and_targets()

--- a/InnerEye/ML/lightning_metrics.py
+++ b/InnerEye/ML/lightning_metrics.py
@@ -252,6 +252,7 @@ class AreaUnderPrecisionRecallCurve(ScalarMetricsBase):
 class BinaryCrossEntropyWithLogits(ScalarMetricsBase):
     """
     Computes the cross entropy for binary classification.
+    This metric must be computed off the output logits
     """
 
     def __init__(self) -> None:

--- a/InnerEye/ML/lightning_metrics.py
+++ b/InnerEye/ML/lightning_metrics.py
@@ -248,7 +248,7 @@ class AreaUnderPrecisionRecallCurve(ScalarMetricsBase):
         return auc(recall, prec)
 
 
-class BinaryCrossEntropy(ScalarMetricsBase):
+class BinaryCrossEntropyWithLogits(ScalarMetricsBase):
     """
     Computes the cross entropy for binary classification.
     """
@@ -258,7 +258,7 @@ class BinaryCrossEntropy(ScalarMetricsBase):
 
     def compute(self) -> torch.Tensor:
         preds, targets = self._get_preds_and_targets()
-        return F.binary_cross_entropy(input=preds, target=targets)
+        return F.binary_cross_entropy_with_logits(input=preds, target=targets)
 
 
 class MetricForMultipleStructures(torch.nn.Module):

--- a/InnerEye/ML/lightning_models.py
+++ b/InnerEye/ML/lightning_models.py
@@ -308,7 +308,10 @@ class ScalarLightning(InnerEyeLightning):
                 _subject_ids = masked.subject_ids
                 assert _subject_ids is not None
                 for metric in metric_list:
-                    metric(_logits, _labels) if (isinstance(metric, ScalarMetricsBase) and metric.compute_from_logits is True) else metric(_posteriors, _labels)
+                    if isinstance(metric, ScalarMetricsBase) and metric.compute_from_logits:
+                        metric(_logits, _labels)
+                    else:
+                        metric(_posteriors, _labels)
                 per_subject_outputs.extend(
                     zip(_subject_ids, [prediction_target] * len(_subject_ids), _posteriors.tolist(), _labels.tolist()))
         # Write a full breakdown of per-subject predictions and labels to a file. These files are local to the current

--- a/InnerEye/ML/lightning_models.py
+++ b/InnerEye/ML/lightning_models.py
@@ -16,7 +16,7 @@ from InnerEye.ML.dataset.sample import CroppedSample
 from InnerEye.ML.dataset.scalar_sample import ScalarItem
 from InnerEye.ML.lightning_base import InnerEyeLightning
 from InnerEye.ML.lightning_metrics import Accuracy05, AccuracyAtOptimalThreshold, AreaUnderPrecisionRecallCurve, \
-    AreaUnderRocCurve, BinaryCrossEntropy, ExplainedVariance, FalseNegativeRateOptimalThreshold, \
+    AreaUnderRocCurve, BinaryCrossEntropyWithLogits, ExplainedVariance, FalseNegativeRateOptimalThreshold, \
     FalsePositiveRateOptimalThreshold, MeanAbsoluteError, MeanSquaredError, MetricForMultipleStructures, \
     OptimalThreshold
 from InnerEye.ML.metrics import compute_dice_across_patches
@@ -222,7 +222,7 @@ class ScalarLightning(InnerEyeLightning):
                                FalseNegativeRateOptimalThreshold(),
                                AreaUnderRocCurve(),
                                AreaUnderPrecisionRecallCurve(),
-                               BinaryCrossEntropy()])
+                               BinaryCrossEntropyWithLogits()])
         else:
             return ModuleList([MeanAbsoluteError(), MeanSquaredError(), ExplainedVariance()])
 

--- a/InnerEye/ML/lightning_models.py
+++ b/InnerEye/ML/lightning_models.py
@@ -18,7 +18,7 @@ from InnerEye.ML.lightning_base import InnerEyeLightning
 from InnerEye.ML.lightning_metrics import Accuracy05, AccuracyAtOptimalThreshold, AreaUnderPrecisionRecallCurve, \
     AreaUnderRocCurve, BinaryCrossEntropyWithLogits, ExplainedVariance, FalseNegativeRateOptimalThreshold, \
     FalsePositiveRateOptimalThreshold, MeanAbsoluteError, MeanSquaredError, MetricForMultipleStructures, \
-    OptimalThreshold
+    OptimalThreshold, ScalarMetricsBase
 from InnerEye.ML.metrics import compute_dice_across_patches
 from InnerEye.ML.metrics_dict import DataframeLogger, MetricsDict, SequenceMetricsDict
 from InnerEye.ML.scalar_config import ScalarModelBase
@@ -301,13 +301,14 @@ class ScalarLightning(InnerEyeLightning):
                 logits[:, i, ...], targets[:, i, ...], subject_ids)
             # compute metrics on valid masked tensors only
             if masked is not None:
-                _posteriors = self.logits_to_posterior(masked.model_outputs.data)
+                _logits = masked.model_outputs.data
+                _posteriors = self.logits_to_posterior(_logits)
                 # Image encoders already prepare images in float16, but the labels are not yet in that dtype
                 _labels = masked.labels.data.to(dtype=_posteriors.dtype)
                 _subject_ids = masked.subject_ids
                 assert _subject_ids is not None
                 for metric in metric_list:
-                    metric(_posteriors, _labels)
+                    metric(_logits, _labels) if (isinstance(metric, ScalarMetricsBase) and metric.compute_from_logits is True) else metric(_posteriors, _labels)
                 per_subject_outputs.extend(
                     zip(_subject_ids, [prediction_target] * len(_subject_ids), _posteriors.tolist(), _labels.tolist()))
         # Write a full breakdown of per-subject predictions and labels to a file. These files are local to the current

--- a/Tests/ML/models/architectures/sequential/test_rnn_classifier.py
+++ b/Tests/ML/models/architectures/sequential/test_rnn_classifier.py
@@ -206,11 +206,7 @@ def test_rnn_classifier_via_config_1(use_combined_model: bool,
                               use_encoder_layer_norm=use_encoder_layer_norm,
                               use_mean_teacher_model=use_mean_teacher_model,
                               should_validate=False)
-    # This fails with 16bit precision, saying "torch.nn.functional.binary_cross_entropy and torch.nn.BCELoss are
-    # unsafe to autocast. Many models use a sigmoid layer right before the binary cross entropy layer. In this case,
-    # combine the two layers using torch.nn.functional.binary_cross_entropy_with_logits or
-    # torch.nn.BCEWithLogitsLoss.  binary_cross_entropy_with_logits and BCEWithLogits are safe to autocast."
-    config.use_mixed_precision = False
+    config.use_mixed_precision = True
     config.set_output_to(test_output_dirs.root_dir)
     config.dataset_data_frame = _get_mock_sequence_dataset()
     # Patch the load_images function that will be called once we access a dataset item

--- a/Tests/ML/models/architectures/test_image_encoder_with_mlp.py
+++ b/Tests/ML/models/architectures/test_image_encoder_with_mlp.py
@@ -263,11 +263,7 @@ def test_image_encoder_with_segmentation(test_output_dirs: OutputFolderForTests,
                           should_validate=False,
                           aggregation_type=aggregation_type,
                           scan_size=scan_size)
-    # This fails with 16bit precision, saying "torch.nn.functional.binary_cross_entropy and torch.nn.BCELoss are
-    # unsafe to autocast. Many models use a sigmoid layer right before the binary cross entropy layer. In this case,
-    # combine the two layers using torch.nn.functional.binary_cross_entropy_with_logits or
-    # torch.nn.BCEWithLogitsLoss.  binary_cross_entropy_with_logits and BCEWithLogits are safe to autocast."
-    config.use_mixed_precision = False
+    config.use_mixed_precision = True
     config.set_output_to(test_output_dirs.root_dir)
     config.num_epochs = 1
     config.local_dataset = Path()

--- a/Tests/ML/test_metrics.py
+++ b/Tests/ML/test_metrics.py
@@ -8,7 +8,9 @@ from typing import List, Optional
 import numpy as np
 import pytest
 import torch
+import torch.nn.functional as F
 from sklearn.metrics import auc, log_loss, precision_recall_curve, roc_curve
+from scipy.special import expit
 
 from InnerEye.Common.metrics_constants import AVERAGE_DICE_SUFFIX, INTERNAL_TO_LOGGING_COLUMN_NAMES, MetricType, \
     TRAIN_PREFIX, \
@@ -171,12 +173,12 @@ def test_classification_metrics() -> None:
     for output, label in zip(outputs, labels):
         for metric in metrics:
             metric.update(output, label)
-    accuracy_05, accuracy_opt, threshold, fpr, fnr, roc_auc, pr_auc, cross_entropy = [metric.compute() for metric in
+    accuracy_05, accuracy_opt, threshold, fpr, fnr, roc_auc, pr_auc, cross_entropy_with_logits = [metric.compute() for metric in
                                                                                       metrics]
     all_labels = torch.cat(labels).numpy()
     all_outputs = torch.cat(outputs).numpy()
     expected_accuracy_at_05 = np.mean((all_outputs > 0.5) == all_labels)
-    expected_binary_cross_entropy = log_loss(y_true=all_labels, y_pred=all_outputs)
+    expected_binary_cross_entropy_with_logits = log_loss(y_true=all_labels, y_pred=expit(all_outputs))
     expected_fpr, expected_tpr, expected_thresholds = roc_curve(y_true=all_labels, y_score=all_outputs)
     expected_roc_auc = auc(expected_fpr, expected_tpr)
     expected_optimal_idx = np.argmax(expected_tpr - expected_fpr)
@@ -192,7 +194,7 @@ def test_classification_metrics() -> None:
     assert fnr == expected_optimal_fnr
     assert roc_auc == expected_roc_auc
     assert pr_auc == expected_pr_auc
-    assert cross_entropy == expected_binary_cross_entropy
+    assert cross_entropy_with_logits == expected_binary_cross_entropy_with_logits
     assert accuracy_05 == expected_accuracy_at_05
 
 

--- a/Tests/ML/test_metrics.py
+++ b/Tests/ML/test_metrics.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 import torch
 from sklearn.metrics import auc, log_loss, precision_recall_curve, roc_curve
-from scipy.special import expit
 
 from InnerEye.Common.metrics_constants import AVERAGE_DICE_SUFFIX, INTERNAL_TO_LOGGING_COLUMN_NAMES, MetricType, \
     TRAIN_PREFIX, \
@@ -18,7 +17,7 @@ from InnerEye.Common.type_annotations import TupleFloat3
 from InnerEye.ML import metrics
 from InnerEye.ML.configs.classification.DummyClassification import DummyClassification
 from InnerEye.ML.configs.regression.DummyRegression import DummyRegression
-from InnerEye.ML.lightning_metrics import AverageWithoutNan, MetricForMultipleStructures
+from InnerEye.ML.lightning_metrics import AverageWithoutNan, MetricForMultipleStructures, ScalarMetricsBase
 from InnerEye.ML.lightning_models import ScalarLightning
 from InnerEye.ML.metrics_dict import MetricsDict, get_column_name_for_logging
 
@@ -167,25 +166,29 @@ def test_get_column_name_for_logging() -> None:
 def test_classification_metrics() -> None:
     classification_module = ScalarLightning(DummyClassification())
     metrics = classification_module._get_metrics_computers()
-    outputs = [torch.tensor([0.9, 0.8, 0.6]), torch.tensor([0.3, 0.9, 0.4])]
+    logits = [torch.tensor([2.1972, 1.3863, 0.4055]), torch.tensor([-0.8473,  2.1972, -0.4055])]
+    posteriors = [torch.sigmoid(logit) for logit in logits]
     labels = [torch.tensor([1., 1., 0.]), torch.tensor([0., 0., 0.])]
-    for output, label in zip(outputs, labels):
+    for logit, posterior, label in zip(logits, posteriors, labels):
         for metric in metrics:
-            metric.update(output, label)
+            if isinstance(metric, ScalarMetricsBase) and metric.compute_from_logits:
+                metric.update(logit, label)
+            else:
+                metric.update(posterior, label)
     accuracy_05, accuracy_opt, threshold, fpr, fnr, roc_auc, pr_auc, cross_entropy_with_logits = [metric.compute() for metric in
                                                                                       metrics]
     all_labels = torch.cat(labels).numpy()
-    all_outputs = torch.cat(outputs).numpy()
-    expected_accuracy_at_05 = np.mean((all_outputs > 0.5) == all_labels)
-    expected_binary_cross_entropy_with_logits = log_loss(y_true=all_labels, y_pred=expit(all_outputs))
-    expected_fpr, expected_tpr, expected_thresholds = roc_curve(y_true=all_labels, y_score=all_outputs)
+    all_posteriors = torch.cat(posteriors).numpy()
+    expected_accuracy_at_05 = np.mean((all_posteriors > 0.5) == all_labels)
+    expected_binary_cross_entropy = log_loss(y_true=all_labels, y_pred=all_posteriors)
+    expected_fpr, expected_tpr, expected_thresholds = roc_curve(y_true=all_labels, y_score=all_posteriors)
     expected_roc_auc = auc(expected_fpr, expected_tpr)
     expected_optimal_idx = np.argmax(expected_tpr - expected_fpr)
     expected_optimal_threshold = expected_thresholds[expected_optimal_idx]
-    expected_accuracy = np.mean((all_outputs > expected_optimal_threshold) == all_labels)
+    expected_accuracy = np.mean((all_posteriors > expected_optimal_threshold) == all_labels)
     expected_optimal_fpr = expected_fpr[expected_optimal_idx]
     expected_optimal_fnr = 1 - expected_tpr[expected_optimal_idx]
-    prec, recall, _ = precision_recall_curve(y_true=all_labels, probas_pred=all_outputs)
+    prec, recall, _ = precision_recall_curve(y_true=all_labels, probas_pred=all_posteriors)
     expected_pr_auc = auc(recall, prec)
     assert accuracy_opt == expected_accuracy
     assert threshold == expected_optimal_threshold
@@ -193,7 +196,9 @@ def test_classification_metrics() -> None:
     assert fnr == expected_optimal_fnr
     assert roc_auc == expected_roc_auc
     assert pr_auc == expected_pr_auc
-    assert cross_entropy_with_logits == expected_binary_cross_entropy_with_logits
+    print(pr_auc, expected_pr_auc)
+    # Use default relative tolerance of one part in a million due to floating point arithmetic
+    assert cross_entropy_with_logits == expected_binary_cross_entropy
     assert accuracy_05 == expected_accuracy_at_05
 
 

--- a/Tests/ML/test_metrics.py
+++ b/Tests/ML/test_metrics.py
@@ -198,7 +198,7 @@ def test_classification_metrics() -> None:
     assert pr_auc == expected_pr_auc
     print(pr_auc, expected_pr_auc)
     # Use default relative tolerance of one part in a million due to floating point arithmetic
-    assert cross_entropy_with_logits == expected_binary_cross_entropy
+    assert cross_entropy_with_logits == pytest.approx(expected_binary_cross_entropy)
     assert accuracy_05 == expected_accuracy_at_05
 
 

--- a/Tests/ML/test_metrics.py
+++ b/Tests/ML/test_metrics.py
@@ -166,7 +166,7 @@ def test_get_column_name_for_logging() -> None:
 def test_classification_metrics() -> None:
     classification_module = ScalarLightning(DummyClassification())
     metrics = classification_module._get_metrics_computers()
-    logits = [torch.tensor([2.1972, 1.3863, 0.4055]), torch.tensor([-0.8473,  2.1972, -0.4055])]
+    logits = [torch.tensor([2.1972, 1.3863, 0.4055]), torch.tensor([-0.8473, 2.1972, -0.4055])]
     posteriors = [torch.sigmoid(logit) for logit in logits]
     labels = [torch.tensor([1., 1., 0.]), torch.tensor([0., 0., 0.])]
     for logit, posterior, label in zip(logits, posteriors, labels):

--- a/Tests/ML/test_metrics.py
+++ b/Tests/ML/test_metrics.py
@@ -8,7 +8,6 @@ from typing import List, Optional
 import numpy as np
 import pytest
 import torch
-import torch.nn.functional as F
 from sklearn.metrics import auc, log_loss, precision_recall_curve, roc_curve
 from scipy.special import expit
 


### PR DESCRIPTION
This PR addresses Issue #401 .

Changes:

- replace `torch.nn.functional.binary_cross_entropy` with `torch.nn.functional.binary_cross_entropy_with_logits` in `lightning_metrics.py`
- rename class `BinaryCrossEntropy` to `BinaryCrossEntropyWithLogits`
- update unit tests in `test_metrics.py`