### PR TITLE
Added possibility to set num_downsampling_paths for Unet as part of model configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ nodes in AzureML. Example: Add `--num_nodes=2` to the commandline arguments to t
   `dataset.csv` supports multiple labels (indices corresponding to `class_names`) per subject in the label column. 
   Multiple labels should be encoded as a string with labels separated by a `|`, for example "0|2|4".
   Note that this PR does not add support for multiclass models, where the labels are mutually exclusive.
+- ([#425](https://github.com/microsoft/InnerEye-DeepLearning/pull/425)) The number of layers in a Unet is no longer fixed at 4, but can be set via the config field `num_downsampled_paths`. A lower number of layers may be useful for decreasing memory requirements, or for working with smaller images. (The minimum image size in any dimension when using a network of n layers is 2**n.)
 
 ### Changed
 - ([#385](https://github.com/microsoft/InnerEye-DeepLearning/pull/385)) Starting an AzureML run now uses the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ nodes in AzureML. Example: Add `--num_nodes=2` to the commandline arguments to t
   `dataset.csv` supports multiple labels (indices corresponding to `class_names`) per subject in the label column. 
   Multiple labels should be encoded as a string with labels separated by a `|`, for example "0|2|4".
   Note that this PR does not add support for multiclass models, where the labels are mutually exclusive.
-- ([#425](https://github.com/microsoft/InnerEye-DeepLearning/pull/425)) The number of layers in a Unet is no longer fixed at 4, but can be set via the config field `num_downsampled_paths`. A lower number of layers may be useful for decreasing memory requirements, or for working with smaller images. (The minimum image size in any dimension when using a network of n layers is 2**n.)
+- ([#425](https://github.com/microsoft/InnerEye-DeepLearning/pull/425)) The number of layers in a Unet is no longer fixed at 4, but can be set via the config field `num_downsampling_paths`. A lower number of layers may be useful for decreasing memory requirements, or for working with smaller images. (The minimum image size in any dimension when using a network of n layers is 2**n.)
 
 ### Changed
 - ([#385](https://github.com/microsoft/InnerEye-DeepLearning/pull/385)) Starting an AzureML run now uses the

--- a/InnerEye/ML/config.py
+++ b/InnerEye/ML/config.py
@@ -264,8 +264,7 @@ class SegmentationModelBase(ModelConfigBase):
 
     #: The number of image levels used in Unet (in encoding and decoding paths).
     num_downsampling_paths: int = param.Integer(4, bounds=(1, None),
-        instantiate=False, doc="The number of image levels used in Unet "
-                               "(in encoding and decoding paths).")
+        instantiate=False, doc="The number of levels used in a UNet architecture in encoding and decoding paths.")
 
     #: The size of the random crops that will be drawn from the input images during training. This is also the
     #: input size of the model.

--- a/InnerEye/ML/config.py
+++ b/InnerEye/ML/config.py
@@ -262,6 +262,11 @@ class SegmentationModelBase(ModelConfigBase):
     #: The size of the convolution kernels.
     kernel_size: int = param.Integer(3, bounds=(1, None), doc="The size of the convolution kernels.")
 
+    #: The number of image levels used in Unet (in encoding and decoding paths).
+    num_downsampling_paths: int = param.Integer(4, bounds=(1, None),
+        instantiate=False, doc="The number of image levels used in Unet "
+                               "(in encoding and decoding paths).")
+
     #: The size of the random crops that will be drawn from the input images during training. This is also the
     #: input size of the model.
     crop_size: TupleInt3 = IntTuple((1, 1, 1), length=3, doc="The size of the random crops that will be "

--- a/InnerEye/ML/utils/model_util.py
+++ b/InnerEye/ML/utils/model_util.py
@@ -105,11 +105,14 @@ def create_scalar_loss_function(config: ScalarModelBase) -> torch.nn.Module:
     Returns a torch module that computes a loss function for classification and regression models.
     """
     if config.loss_type == ScalarLoss.BinaryCrossEntropyWithLogits:
-        return BinaryCrossEntropyWithLogitsLoss(smoothing_eps=config.label_smoothing_eps)
+        return BinaryCrossEntropyWithLogitsLoss(num_classes=len(config.class_names),
+                                                smoothing_eps=config.label_smoothing_eps)
     if config.loss_type == ScalarLoss.WeightedCrossEntropyWithLogits:
         return BinaryCrossEntropyWithLogitsLoss(
+            num_classes=len(config.class_names),
             smoothing_eps=config.label_smoothing_eps,
-            class_counts=config.get_training_class_counts())
+            class_counts=config.get_training_class_counts(),
+            num_train_samples=config.get_total_number_of_training_samples())
     elif config.loss_type == ScalarLoss.MeanSquaredError:
         return MSELoss()
     else:

--- a/InnerEye/ML/utils/model_util.py
+++ b/InnerEye/ML/utils/model_util.py
@@ -105,14 +105,11 @@ def create_scalar_loss_function(config: ScalarModelBase) -> torch.nn.Module:
     Returns a torch module that computes a loss function for classification and regression models.
     """
     if config.loss_type == ScalarLoss.BinaryCrossEntropyWithLogits:
-        return BinaryCrossEntropyWithLogitsLoss(num_classes=len(config.class_names),
-                                                smoothing_eps=config.label_smoothing_eps)
+        return BinaryCrossEntropyWithLogitsLoss(smoothing_eps=config.label_smoothing_eps)
     if config.loss_type == ScalarLoss.WeightedCrossEntropyWithLogits:
         return BinaryCrossEntropyWithLogitsLoss(
-            num_classes=len(config.class_names),
             smoothing_eps=config.label_smoothing_eps,
-            class_counts=config.get_training_class_counts(),
-            num_train_samples=config.get_total_number_of_training_samples())
+            class_counts=config.get_training_class_counts())
     elif config.loss_type == ScalarLoss.MeanSquaredError:
         return MSELoss()
     else:
@@ -160,14 +157,16 @@ def build_net(args: SegmentationModelBase) -> BaseSegmentationModel:
         network = UNet3D(input_image_channels=args.number_of_image_channels,
                          initial_feature_channels=args.feature_channels[0],
                          num_classes=args.number_of_classes,
-                         kernel_size=args.kernel_size)
+                         kernel_size=args.kernel_size,
+                         num_downsampling_paths=args.num_downsampling_paths)
         run_weight_initialization = False
 
     elif args.architecture == ModelArchitectureConfig.UNet2D:
         network = UNet2D(input_image_channels=args.number_of_image_channels,
                          initial_feature_channels=args.feature_channels[0],
                          num_classes=args.number_of_classes,
-                         padding_mode=PaddingMode.Edge)
+                         padding_mode=PaddingMode.Edge,
+                         num_downsampling_paths=args.num_downsampling_paths)
         run_weight_initialization = False
 
     else:


### PR DESCRIPTION
The `Unet` parameter `num_downsampling_paths` defines the number of network layers.  It was previously always set to `4`, but can now be modified as a part of model configuration.  The default value remains `4`.  A lower value may be useful for decreasing memory requirements, of for working with shorter images.  (The minimum number of image slices required when using a network of `n` layers is `2**n`.)

The parameter `num-downsampling-paths` is initialised in [InnerEye/ML/config.py](https://github.com/kh296/InnerEye-DeepLearning/blob/977e78c6f355a7b71f1617273b45289f04e6d55b/InnerEye/ML/config.py#L265), then is used in `Unet` creation in the `build_net()` function of [InnerEye/ML/utils/model_util.py](https://github.com/kh296/InnerEye-DeepLearning/blob/977e78c6f355a7b71f1617273b45289f04e6d55b/InnerEye/ML/utils/model_util.py#L156).  An associated unit test has been added to [Tests/ML/test_config_helpers.py](https://github.com/kh296/InnerEye-DeepLearning/blob/977e78c6f355a7b71f1617273b45289f04e6d55b/Tests/ML/test_config_helpers.py#L179).
