### PR TITLE
Move basic PR checks like Flake8, Mypy and HelloWorld to Github actions

### DIFF
--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -3,6 +3,8 @@ name: Flake8, MyPy, and Hello World
 # This workflow runs linting via Flake8 and Mypy.
 # It also checks that the HelloWorld model can be trained.
 
+
+# TODO antonsc: change back to trigger on PR
 on:
   push:
     branches:
@@ -15,14 +17,17 @@ jobs:
         with:
           lfs: true
 
-      # Run Flake8 first, to fail as quickly as possible
       - name: flake8
         run: |
           pip install flake8
           python -m flake8
         shell: bash
         if: always()        
-        
+
+      # This script also does "conda init" for all shells. For bash, this modifies .bashrc.
+      # However, the default "bash" in a github workflow does not execute bashrc. Hence, all
+      # scripts that use this environment need to either hardcode the path to Python, or use
+      # a customized shell that executes bashrc, like "shell: bash -eo pipefail {0}"
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: InnerEye
@@ -33,8 +38,7 @@ jobs:
 
       - name: mypy
         run: |
-          python mypy_runner.py --mypy=$CONDA/envs/InnerEye/bin/mypy
-        shell: bash -eo pipefail {0}
+          $CONDA/envs/InnerEye/bin/python mypy_runner.py --mypy=$CONDA/envs/InnerEye/bin/mypy
         if: always()
 
       - name: Run HelloWorld model
@@ -42,7 +46,6 @@ jobs:
           $CONDA/envs/InnerEye/bin/python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}
-        shell: bash -eo pipefail {0}
         if: always()
 
   windows:

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: mypy
         run: |
-          $CONDA/envs/InnerEye/bin/python mypy_runner.py --mypy=$CONDA/envs/InnerEye/bin/mypy
-        shell: bash
+          python mypy_runner.py --mypy=$CONDA/envs/InnerEye/bin/mypy
+        shell: bash -eo pipefail {0}
         if: always()
 
       - name: Run HelloWorld model
@@ -42,7 +42,7 @@ jobs:
           $CONDA/envs/InnerEye/bin/python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}
-        shell: bash
+        shell: bash -eo pipefail {0}
         if: always()
 
   windows:

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -21,7 +21,7 @@ jobs:
         shell: bash
 
       - name: Print conda version and initial package list
-      - run: |
+        run: |
           conda install conda=4.8.3 -y
           conda --version
           conda list

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: InnerEye
+          auto-activate-base: false
           environment-file: environment.yml
           python-version: 3.7
         if: always()
@@ -54,6 +55,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: InnerEye
+          auto-activate-base: false
           environment-file: environment.yml
           python-version: 3.7
         if: always()

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -65,10 +65,12 @@ jobs:
           $CONDA\Scripts\conda install conda=4.8.3 -y
           $CONDA\Scripts\conda --version
           $CONDA\Scripts\conda list
+        shell: cmd
 
       - name: Create conda environment
         run: |
           $CONDA\Scripts\conda env create --file environment.yml --name InnerEye --quiet
+        shell: cmd
 
       - name: Run HelloWorld model
         run: |
@@ -76,3 +78,4 @@ jobs:
           python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}
+        shell: cmd

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -53,26 +53,22 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-              
-      - name: Add Conda to PATH
-        run: |
-          echo "$CONDA/Scripts/" >> $GITHUB_PATH
 
       - name: Print conda version and initial package list
         run: |
-          conda install conda=4.8.3 -y
-          conda --version
-          conda list
+          $CONDA/Scripts/conda install conda=4.8.3 -y
+          $CONDA/Scripts/conda --version
+          $CONDA/Scripts/conda list
         shell: bash
 
       - name: Create conda environment
         run: |
-          conda env create --file environment.yml --name InnerEye --quiet
+          $CONDA/Scripts/conda env create --file environment.yml --name InnerEye --quiet
         shell: bash
 
       - name: Run HelloWorld model
         run: |
-          activate InnerEye
+          $CONDA/Scripts/activate InnerEye
           python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -38,13 +38,13 @@ jobs:
 
       - name: mypy
         run: |
-          activate InnerEye
+          conda activate InnerEye
           python mypy_runner.py --mypy=$CONDA/envs/InnerEye/bin/mypy
         shell: bash
 
       - name: Run HelloWorld model
         run: |
-          activate InnerEye
+          conda activate InnerEye
           python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Run HelloWorld model
         run: |
-          $CONDA/Scripts/activate InnerEye
+          $CONDA/Scripts/conda activate InnerEye
           python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -39,7 +39,7 @@ jobs:
       - name: mypy
         run: |
           activate InnerEye
-          python mypy_runner.py
+          python mypy_runner.py --mypy=$CONDA/envs/InnerEye/bin/mypy
         shell: bash
 
       - name: Run HelloWorld model

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -59,4 +59,6 @@ jobs:
         run: |
           source activate InnerEye
           python ./InnerEye/ML/runner.py --model=HelloWorld
+        env:
+          PYTHONPATH: {{ github.workspace }}
         shell: bash

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -9,7 +9,10 @@ on:
       - antonsc/linting
 jobs:
   check:
-    runs-on: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - name: Add conda to PATH

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Print conda version and initial package list
         run: |
+          echo $CONDA
           $CONDA\Scripts\conda install conda=4.8.3 -y
           $CONDA\Scripts\conda --version
           $CONDA\Scripts\conda list

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -4,7 +4,9 @@ name: Flake8, MyPy, and Hello World
 # It also checks that the HelloWorld model can be trained.
 
 on:
-  pull_request:
+  push:
+    branches:
+      - antonsc/linting
 jobs:
   check:
     runs-on: [ubuntu-latest, windows-latest]

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run HelloWorld model
         run: |
-          $CONDA/envs/InnerEye/bin/python ./InnerEye/ML/runner.py --model=HelloWorld
+          %CONDA%\envs\InnerEye\bin\python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}
         shell: cmd

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -33,13 +33,13 @@ jobs:
 
       - name: mypy
         run: |
-          python mypy_runner.py
+          $CONDA/envs/InnerEye/bin/python mypy_runner.py --mypy=$CONDA/envs/InnerEye/bin/mypy
         shell: bash
         if: always()
 
       - name: Run HelloWorld model
         run: |
-          python ./InnerEye/ML/runner.py --model=HelloWorld
+          $CONDA/envs/InnerEye/bin/python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}
         shell: bash
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run HelloWorld model
         run: |
-          python ./InnerEye/ML/runner.py --model=HelloWorld
+          $CONDA/envs/InnerEye/bin/python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}
         shell: cmd

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -1,0 +1,64 @@
+name: Flake8, MyPy, and Hello World
+
+# This workflow runs linting via Flake8 and Mypy.
+# It also checks that the HelloWorld model can be trained.
+
+on:
+  pull_request:
+jobs:
+  check:
+    runs-on: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Add conda to PATH
+        run: |
+          if [ $(Agent.OS) = 'Windows_NT' ]
+          then subdir=Scripts
+          else subdir=bin
+          fi
+          echo "Adding this directory to PATH: $CONDA/$subdir"
+          echo "##vso[task.prependpath]$CONDA/$subdir"
+        shell: bash
+
+      - name: Print conda version and initial package list
+      - run: |
+          conda install conda=4.8.3 -y
+          conda --version
+          conda list
+        shell: bash
+
+      - name: Take ownership of conda installation
+        run: |
+          sudo chown -R $USER /usr/share/miniconda
+        condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ))
+
+      - name: Create conda environment
+        run: |
+          conda env create --file environment.yml --name InnerEye --quiet
+          source activate InnerEye
+          echo Storing environment for later use by ComponentGovernance
+          # This file is picked up later by ComponentGovernance
+          pip freeze > requirements.txt
+          echo Environment has been created with these packages:
+          cat requirements.txt
+        shell: bash
+
+      - name: flake8
+        run: |
+          source activate InnerEye
+          flake8
+        shell: bash
+
+      - name: mypy
+        run: |
+          source activate InnerEye
+          python mypy_runner.py
+        shell: bash
+
+      - name: Run HelloWorld model
+        run: |
+          source activate InnerEye
+          python ./InnerEye/ML/runner.py --model=HelloWorld
+        env:
+          PYTHONPATH: `pwd`
+        shell: bash

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -29,6 +29,7 @@ jobs:
           conda install conda=4.8.3 -y
           conda --version
           conda list
+          conda init bash
         shell: bash
 
       - name: Create conda environment

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Run Flake8 first, to fail as quicly as possible
+      # Run Flake8 first, to fail as quickly as possible
       - name: flake8
         run: |
           pip install flake8
-          flake8
+          python -m flake8
         shell: bash
         
       - name: Print conda version and initial package list

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Run HelloWorld model
         run: |
+          conda info
           %CONDA%\envs\InnerEye\bin\python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
 
       # Run Flake8 first, to fail as quickly as possible
       - name: flake8
@@ -59,6 +61,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Print conda version and initial package list
         run: |
@@ -66,6 +70,7 @@ jobs:
           %CONDA%\Scripts\conda install conda=4.8.3 -y
           %CONDA%\Scripts\conda --version
           %CONDA%\Scripts\conda list
+          %CONDA%\Scripts\conda init cmd.exe
         shell: cmd
 
       - name: Create conda environment

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -62,20 +62,20 @@ jobs:
 
       - name: Print conda version and initial package list
         run: |
-          echo $CONDA
-          $CONDA\Scripts\conda install conda=4.8.3 -y
-          $CONDA\Scripts\conda --version
-          $CONDA\Scripts\conda list
+          echo %CONDA%
+          %CONDA%\Scripts\conda install conda=4.8.3 -y
+          %CONDA%\Scripts\conda --version
+          %CONDA%\Scripts\conda list
         shell: cmd
 
       - name: Create conda environment
         run: |
-          $CONDA\Scripts\conda env create --file environment.yml --name InnerEye --quiet
+          %CONDA%\Scripts\conda env create --file environment.yml --name InnerEye --quiet
         shell: cmd
 
       - name: Run HelloWorld model
         run: |
-          $CONDA\Scripts\conda activate InnerEye
+          %CONDA%\Scripts\conda activate InnerEye
           python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -19,11 +19,13 @@ jobs:
           pip install flake8
           python -m flake8
         shell: bash
+        if: always()        
         
       - name: Add Conda to PATH
         run: |
           echo "$CONDA/bin/" >> $GITHUB_PATH
-          
+        if: always()
+        
       - name: Print conda version and initial package list
         run: |
           conda install conda=4.8.3 -y
@@ -31,17 +33,20 @@ jobs:
           conda list
           conda init bash
         shell: bash
+        if: always()
 
       - name: Create conda environment
         run: |
           conda env create --file environment.yml --name InnerEye --quiet
         shell: bash
+        if: always()
 
       - name: mypy
         run: |
           conda activate InnerEye
           python mypy_runner.py --mypy=$CONDA/envs/InnerEye/bin/mypy
         shell: bash
+        if: always()
 
       - name: Run HelloWorld model
         run: |
@@ -50,6 +55,8 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
         shell: bash
+        if: always()
+
   windows:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -12,6 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      # Run Flake8 first, to fail as quicly as possible
+      - name: flake8
+        run: |
+          pip install flake8
+          flake8
+        shell: bash
+        
       - name: Print conda version and initial package list
         run: |
           $CONDA/bin/conda install conda=4.8.3 -y
@@ -22,12 +30,6 @@ jobs:
       - name: Create conda environment
         run: |
           $CONDA/bin/conda env create --file environment.yml --name InnerEye --quiet
-        shell: bash
-
-      - name: flake8
-        run: |
-          activate InnerEye
-          flake8
         shell: bash
 
       - name: mypy
@@ -47,6 +49,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
+      
       - name: Print conda version and initial package list
         run: |
           $CONDA/Scripts/conda install conda=4.8.3 -y

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -62,17 +62,17 @@ jobs:
 
       - name: Print conda version and initial package list
         run: |
-          $CONDA/Scripts/conda install conda=4.8.3 -y
-          $CONDA/Scripts/conda --version
-          $CONDA/Scripts/conda list
+          $CONDA\Scripts\conda install conda=4.8.3 -y
+          $CONDA\Scripts\conda --version
+          $CONDA\Scripts\conda list
 
       - name: Create conda environment
         run: |
-          $CONDA/Scripts/conda env create --file environment.yml --name InnerEye --quiet
+          $CONDA\Scripts\conda env create --file environment.yml --name InnerEye --quiet
 
       - name: Run HelloWorld model
         run: |
-          $CONDA/Scripts/conda activate InnerEye
+          $CONDA\Scripts\conda activate InnerEye
           python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: true
+          lfs: true
 
       # Run Flake8 first, to fail as quickly as possible
       - name: flake8
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: true
+          lfs: true
 
       - name: Print conda version and initial package list
         run: |

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -3,12 +3,9 @@ name: Flake8, MyPy, and Hello World
 # This workflow runs linting via Flake8 and Mypy.
 # It also checks that the HelloWorld model can be trained.
 
-
-# TODO antonsc: change back to trigger on PR
 on:
-  push:
-    branches:
-      - antonsc/linting
+  pull_request:
+
 jobs:
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Take ownership of conda installation
         run: |
           sudo chown -R $USER /usr/share/miniconda
-        if: ${{runner.os == "Linux"}}
+        if: ${{runner.os == 'Linux'}}
 
       - name: Create conda environment
         run: |

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -43,15 +43,13 @@ jobs:
 
       - name: mypy
         run: |
-          conda activate InnerEye
-          python mypy_runner.py --mypy=$CONDA/envs/InnerEye/bin/mypy
+          $CONDA/envs/InnerEye/bin/python mypy_runner.py --mypy=$CONDA/envs/InnerEye/bin/mypy
         shell: bash
         if: always()
 
       - name: Run HelloWorld model
         run: |
-          conda activate InnerEye
-          python ./InnerEye/ML/runner.py --model=HelloWorld
+          $CONDA/envs/InnerEye/bin/python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}
         shell: bash
@@ -67,12 +65,10 @@ jobs:
           $CONDA/Scripts/conda install conda=4.8.3 -y
           $CONDA/Scripts/conda --version
           $CONDA/Scripts/conda list
-        shell: bash
 
       - name: Create conda environment
         run: |
           $CONDA/Scripts/conda env create --file environment.yml --name InnerEye --quiet
-        shell: bash
 
       - name: Run HelloWorld model
         run: |
@@ -80,4 +76,3 @@ jobs:
           python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}
-        shell: bash

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -26,19 +26,19 @@ jobs:
 
       - name: flake8
         run: |
-          source activate InnerEye
+          activate InnerEye
           flake8
         shell: bash
 
       - name: mypy
         run: |
-          source activate InnerEye
+          activate InnerEye
           python mypy_runner.py
         shell: bash
 
       - name: Run HelloWorld model
         run: |
-          source activate InnerEye
+          activate InnerEye
           python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run HelloWorld model
         run: |
-          source activate InnerEye
+          activate InnerEye
           python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -20,16 +20,20 @@ jobs:
           python -m flake8
         shell: bash
         
+      - name: Add Conda to PATH
+        run: |
+          echo "$CONDA/bin/" >> $GITHUB_PATH
+          
       - name: Print conda version and initial package list
         run: |
-          $CONDA/bin/conda install conda=4.8.3 -y
-          $CONDA/bin/conda --version
-          $CONDA/bin/conda list
+          conda install conda=4.8.3 -y
+          conda --version
+          conda list
         shell: bash
 
       - name: Create conda environment
         run: |
-          $CONDA/bin/conda env create --file environment.yml --name InnerEye --quiet
+          conda env create --file environment.yml --name InnerEye --quiet
         shell: bash
 
       - name: mypy
@@ -49,17 +53,21 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      
+              
+      - name: Add Conda to PATH
+        run: |
+          echo "$CONDA/Scripts/" >> $GITHUB_PATH
+
       - name: Print conda version and initial package list
         run: |
-          $CONDA/Scripts/conda install conda=4.8.3 -y
-          $CONDA/Scripts/conda --version
-          $CONDA/Scripts/conda list
+          conda install conda=4.8.3 -y
+          conda --version
+          conda list
         shell: bash
 
       - name: Create conda environment
         run: |
-          $CONDA/Scripts/conda env create --file environment.yml --name InnerEye --quiet
+          conda env create --file environment.yml --name InnerEye --quiet
         shell: bash
 
       - name: Run HelloWorld model

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -59,6 +59,4 @@ jobs:
         run: |
           source activate InnerEye
           python ./InnerEye/ML/runner.py --model=HelloWorld
-        env:
-          PYTHONPATH: `pwd`
         shell: bash

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -23,35 +23,22 @@ jobs:
         shell: bash
         if: always()        
         
-      - name: Add Conda to PATH
-        run: |
-          echo "$CONDA/bin/" >> $GITHUB_PATH
-        if: always()
-        
-      - name: Print conda version and initial package list
-        run: |
-          conda install conda=4.8.3 -y
-          conda --version
-          conda list
-          conda init bash
-        shell: bash
-        if: always()
-
-      - name: Create conda environment
-        run: |
-          conda env create --file environment.yml --name InnerEye --quiet
-        shell: bash
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: InnerEye
+          environment-file: environment.yml
+          python-version: 3.7
         if: always()
 
       - name: mypy
         run: |
-          $CONDA/envs/InnerEye/bin/python mypy_runner.py --mypy=$CONDA/envs/InnerEye/bin/mypy
+          python mypy_runner.py
         shell: bash
         if: always()
 
       - name: Run HelloWorld model
         run: |
-          $CONDA/envs/InnerEye/bin/python ./InnerEye/ML/runner.py --model=HelloWorld
+          python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}
         shell: bash
@@ -63,24 +50,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           lfs: true
-
-      - name: Print conda version and initial package list
-        run: |
-          echo %CONDA%
-          %CONDA%\Scripts\conda install conda=4.8.3 -y
-          %CONDA%\Scripts\conda --version
-          %CONDA%\Scripts\conda list
-          %CONDA%\Scripts\conda init cmd.exe
-        shell: cmd
-
-      - name: Create conda environment
-        run: |
-          %CONDA%\Scripts\conda env create --file environment.yml --name InnerEye --quiet
-        shell: cmd
+          
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: InnerEye
+          environment-file: environment.yml
+          python-version: 3.7
+        if: always()
 
       - name: Run HelloWorld model
         run: |
-          %CONDA%\Scripts\conda activate InnerEye
           python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -8,44 +8,20 @@ on:
     branches:
       - antonsc/linting
 jobs:
-  check:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
+  linux:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Add conda to PATH
-        run: |
-          if [ $(Agent.OS) = 'Windows_NT' ]
-          then subdir=Scripts
-          else subdir=bin
-          fi
-          echo "Adding this directory to PATH: $CONDA/$subdir"
-          echo "##vso[task.prependpath]$CONDA/$subdir"
-        shell: bash
-
       - name: Print conda version and initial package list
         run: |
-          conda install conda=4.8.3 -y
-          conda --version
-          conda list
+          $CONDA/bin/conda install conda=4.8.3 -y
+          $CONDA/bin/conda --version
+          $CONDA/bin/conda list
         shell: bash
-
-      - name: Take ownership of conda installation
-        run: |
-          sudo chown -R $USER /usr/share/miniconda
-        if: ${{runner.os == 'Linux'}}
 
       - name: Create conda environment
         run: |
-          conda env create --file environment.yml --name InnerEye --quiet
-          source activate InnerEye
-          echo Storing environment for later use by ComponentGovernance
-          # This file is picked up later by ComponentGovernance
-          pip freeze > requirements.txt
-          echo Environment has been created with these packages:
-          cat requirements.txt
+          $CONDA/bin/conda env create --file environment.yml --name InnerEye --quiet
         shell: bash
 
       - name: flake8
@@ -58,6 +34,29 @@ jobs:
         run: |
           source activate InnerEye
           python mypy_runner.py
+        shell: bash
+
+      - name: Run HelloWorld model
+        run: |
+          source activate InnerEye
+          python ./InnerEye/ML/runner.py --model=HelloWorld
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        shell: bash
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print conda version and initial package list
+        run: |
+          $CONDA/Scripts/conda install conda=4.8.3 -y
+          $CONDA/Scripts/conda --version
+          $CONDA/Scripts/conda list
+        shell: bash
+
+      - name: Create conda environment
+        run: |
+          $CONDA/Scripts/conda env create --file environment.yml --name InnerEye --quiet
         shell: bash
 
       - name: Run HelloWorld model

--- a/.github/workflows/linting_and_hello_world.yml
+++ b/.github/workflows/linting_and_hello_world.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Take ownership of conda installation
         run: |
           sudo chown -R $USER /usr/share/miniconda
-        condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ))
+        if: ${{runner.os == "Linux"}}
 
       - name: Create conda environment
         run: |
@@ -60,5 +60,5 @@ jobs:
           source activate InnerEye
           python ./InnerEye/ML/runner.py --model=HelloWorld
         env:
-          PYTHONPATH: {{ github.workspace }}
+          PYTHONPATH: ${{ github.workspace }}
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,12 @@ nodes in AzureML. Example: Add `--num_nodes=2` to the commandline arguments to t
   `dataset.csv` supports multiple labels (indices corresponding to `class_names`) per subject in the label column. 
   Multiple labels should be encoded as a string with labels separated by a `|`, for example "0|2|4".
   Note that this PR does not add support for multiclass models, where the labels are mutually exclusive.
-- ([#425](https://github.com/microsoft/InnerEye-DeepLearning/pull/425)) The number of layers in a Unet is no longer fixed at 4, but can be set via the config field `num_downsampling_paths`. A lower number of layers may be useful for decreasing memory requirements, or for working with smaller images. (The minimum image size in any dimension when using a network of n layers is 2**n.)
+- ([#425](https://github.com/microsoft/InnerEye-DeepLearning/pull/425)) The number of layers in a Unet is no longer 
+  fixed at 4, but can be set via the config field `num_downsampling_paths`. A lower number of layers may be useful 
+  for decreasing memory requirements, or for working with smaller images. 
+  (The minimum image size in any dimension when using a network of n layers is 2**n.)
+- ([#426](https://github.com/microsoft/InnerEye-DeepLearning/pull/426)) Flake8, mypy, and testing the HelloWorld model
+  is now happening in a Github action, no longer in Azure Pipelines.
 
 ### Changed
 - ([#385](https://github.com/microsoft/InnerEye-DeepLearning/pull/385)) Starting an AzureML run now uses the

--- a/InnerEye/ML/metrics.py
+++ b/InnerEye/ML/metrics.py
@@ -30,6 +30,8 @@ from InnerEye.ML.utils.metrics_util import binary_classification_accuracy, mean_
 from InnerEye.ML.utils.ml_util import check_size_matches
 from InnerEye.ML.utils.sequence_utils import get_masked_model_outputs_and_labels
 
+import datetime
+
 MAX_ITEM_LOAD_TIME_SEC = 0.5
 MAX_LOAD_TIME_WARNINGS = 3
 MAX_LOAD_TIME_EPOCHS = 5
@@ -348,6 +350,8 @@ def store_epoch_metrics(metrics: DictStrFloat,
             hue_suffix = "/" + tokens[1]
         else:
             raise ValueError(f"Expected key to have format 'metric_name[/optional_suffix_for_hue]', got {key}")
+
+
 
         if metric_name == MetricType.SECONDS_PER_BATCH.value or metric_name == MetricType.SECONDS_PER_EPOCH.value:
             continue

--- a/InnerEye/ML/metrics.py
+++ b/InnerEye/ML/metrics.py
@@ -30,8 +30,6 @@ from InnerEye.ML.utils.metrics_util import binary_classification_accuracy, mean_
 from InnerEye.ML.utils.ml_util import check_size_matches
 from InnerEye.ML.utils.sequence_utils import get_masked_model_outputs_and_labels
 
-import datetime
-
 MAX_ITEM_LOAD_TIME_SEC = 0.5
 MAX_LOAD_TIME_WARNINGS = 3
 MAX_LOAD_TIME_EPOCHS = 5
@@ -350,8 +348,6 @@ def store_epoch_metrics(metrics: DictStrFloat,
             hue_suffix = "/" + tokens[1]
         else:
             raise ValueError(f"Expected key to have format 'metric_name[/optional_suffix_for_hue]', got {key}")
-
-
 
         if metric_name == MetricType.SECONDS_PER_BATCH.value or metric_name == MetricType.SECONDS_PER_EPOCH.value:
             continue

--- a/InnerEye/ML/reports/notebook_report.py
+++ b/InnerEye/ML/reports/notebook_report.py
@@ -68,7 +68,9 @@ def generate_notebook(template_notebook: Path, notebook_params: Dict, result_not
     papermill.execute_notebook(input_path=str(template_notebook),
                                output_path=str(result_notebook),
                                parameters=notebook_params,
-                               progress_bar=False)
+                               progress_bar=False,
+                               # Unit tests often fail with cell timeouts when default of 4 is used.
+                               iopub_timeout=10)
     return convert_to_html(result_notebook)
 
 

--- a/azure-pipelines/build.yaml
+++ b/azure-pipelines/build.yaml
@@ -26,31 +26,6 @@ steps:
     condition: succeeded()
     displayName: Create conda environment
 
-  - bash: |
-      source activate InnerEye
-      flake8
-    failOnStderr: true
-    condition: succeededOrFailed()
-    displayName: flake8
-
-  - bash: |
-      source activate InnerEye
-      python mypy_runner.py
-    failOnStderr: true
-    condition: succeededOrFailed()
-    displayName: mypy
-
-  # Build the HelloWorld model, without providing the secrets for the ServicePrincipal, to mimic running HelloWorld
-  # right after checking out. This must happen before we provide any additional information in settings.yml
-  - bash: |
-      source activate InnerEye
-      python ./InnerEye/ML/runner.py --model=HelloWorld
-    env:
-      PYTHONPATH: $(Build.SourcesDirectory)/
-    failOnStderr: false
-    condition: succeededOrFailed()
-    displayName: Run HelloWorld model
-
   # Pytest needs subscription information directly in settings.yml. Local package install will cause use of
   # the wrong default project root, hence InnerEyePrivateSettings.yml can't be picked up.
   - bash: |


### PR DESCRIPTION
At present, external contributors don't have any insight into why the PR builds fail because they run on ADO.
This PR moves some of the basic checks to Github Actions, where they are fully visible: Flake8, mypy, and training the `HelloWorld` model. All those 3 components now run as Github actions on Linux. On Windows (which takes longer to set up) only `HelloWorld` is run. 