### PR TITLE
Guard plot_cross_validation.save_outliers for institutionId and seriesId columns confirm with unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ created.
 ## Upcoming
 
 ### Added
+
+- ([#446](https://github.com/microsoft/InnerEye-DeepLearning/pull/446)) Guarding `save_outlier` so that it works when 
+institution id and series id columns are missing.
 - ([#441](https://github.com/microsoft/InnerEye-DeepLearning/pull/441)) Add script to move models from one AzureML workspace to another: `python InnerEye/Scripts/move_model.py`
 - ([#417](https://github.com/microsoft/InnerEye-DeepLearning/pull/417)) Added a generic way of adding PyTorch Lightning
 models to the toolbox. It is now possible to train almost any Lightning model with the InnerEye toolbox in AzureML,

--- a/InnerEye/ML/visualizers/plot_cross_validation.py
+++ b/InnerEye/ML/visualizers/plot_cross_validation.py
@@ -676,9 +676,11 @@ def save_outliers(config: PlotCrossValidationConfig,
 
                     f.write(f"\n\n=== METRIC: {metric_type} ===\n\n")
                     if len(outliers) > 0:
-                        outliers_summary = str(outliers.groupby(
-                            [MetricsFileColumns.Patient.value, MetricsFileColumns.Structure.value,
-                             CSV_SERIES_HEADER, CSV_INSTITUTION_HEADER])
+                        # If running inside institution there may be no CSV_SERIES_HEADER and CSV_INSTITUTION_HEADER columns
+                        groupby_columns = [MetricsFileColumns.Patient.value, MetricsFileColumns.Structure.value]
+                        if CSV_SERIES_HEADER in outliers.columns and CSV_INSTITUTION_HEADER in outliers.columns:
+                            groupby_columns += [CSV_SERIES_HEADER, CSV_INSTITUTION_HEADER]
+                        outliers_summary = str(outliers.groupby(groupby_columns)
                                                .describe()[metric_type][stats_columns]
                                                .sort_values(stats_columns, ascending=False))
                         f.write(outliers_summary)

--- a/InnerEye/ML/visualizers/plot_cross_validation.py
+++ b/InnerEye/ML/visualizers/plot_cross_validation.py
@@ -699,7 +699,7 @@ def create_portal_query_for_outliers(df: pd.DataFrame) -> str:
 
     The passed data frame must have CSV_INSTITUTION_HEADER and CSV_SERIES_HEADER columns
     """
-    if not CSV_INSTITUTION_HEADER in df.columns or not CSV_SERIES_HEADER in df.columns:
+    if CSV_INSTITUTION_HEADER not in df.columns or CSV_SERIES_HEADER not in df.columns:
         raise ValueError(f"Data frame must have columns {CSV_INSTITUTION_HEADER} and {CSV_SERIES_HEADER}")
     return PORTAL_QUERY_TEMPLATE.format(
         " OR ".join(map(lambda x: 'r.InstitutionId = "{}"'.format(x), df[CSV_INSTITUTION_HEADER].unique())),

--- a/Tests/ML/test_data/Val_outliers_pruned.txt
+++ b/Tests/ML/test_data/Val_outliers_pruned.txt
@@ -1,0 +1,56 @@
+
+
+=== METRIC: Dice ===
+
+                         count  mean  min  max
+Patient Structure                             
+341     rectum           1.0    1.1   1.1  1.1
+366     rectum           1.0    0.9   0.9  0.9
+411     rectum           1.0    0.9   0.9  0.9
+306     rectum           1.0    0.8   0.8  0.8
+344     rectum           1.0    0.8   0.8  0.8
+365     rectum           1.0    0.7   0.7  0.7
+343     rectum           1.0    0.4   0.4  0.4
+409     rectum           1.0    0.4   0.4  0.4
+320     rectum           1.0    0.3   0.3  0.3
+374     rectum           1.0    0.2   0.2  0.2
+341     femur_r          1.0    0.1   0.1  0.1
+366     seminalvesicles  1.0    0.1   0.1  0.1
+306     bladder          1.0    0.0   0.0  0.0
+        femur_r          1.0    0.0   0.0  0.0
+        prostate         1.0    0.0   0.0  0.0
+        seminalvesicles  1.0    0.0   0.0  0.0
+320     bladder          1.0    0.0   0.0  0.0
+        femur_r          1.0    0.0   0.0  0.0
+        prostate         1.0    0.0   0.0  0.0
+        seminalvesicles  1.0    0.0   0.0  0.0
+341     bladder          1.0    0.0   0.0  0.0
+        prostate         1.0    0.0   0.0  0.0
+        seminalvesicles  1.0    0.0   0.0  0.0
+343     bladder          1.0    0.0   0.0  0.0
+        femur_r          1.0    0.0   0.0  0.0
+        prostate         1.0    0.0   0.0  0.0
+        seminalvesicles  1.0    0.0   0.0  0.0
+344     bladder          1.0    0.0   0.0  0.0
+        femur_r          1.0    0.0   0.0  0.0
+        prostate         1.0    0.0   0.0  0.0
+        seminalvesicles  1.0    0.0   0.0  0.0
+365     bladder          1.0    0.0   0.0  0.0
+        femur_r          1.0    0.0   0.0  0.0
+        prostate         1.0    0.0   0.0  0.0
+        seminalvesicles  1.0    0.0   0.0  0.0
+366     bladder          1.0    0.0   0.0  0.0
+        femur_r          1.0    0.0   0.0  0.0
+        prostate         1.0    0.0   0.0  0.0
+374     bladder          1.0    0.0   0.0  0.0
+        femur_r          1.0    0.0   0.0  0.0
+        prostate         1.0    0.0   0.0  0.0
+        seminalvesicles  1.0    0.0   0.0  0.0
+409     bladder          1.0    0.0   0.0  0.0
+        femur_r          1.0    0.0   0.0  0.0
+        prostate         1.0    0.0   0.0  0.0
+        seminalvesicles  1.0    0.0   0.0  0.0
+411     bladder          1.0    0.0   0.0  0.0
+        femur_r          1.0    0.0   0.0  0.0
+        prostate         1.0    0.0   0.0  0.0
+        seminalvesicles  1.0    0.0   0.0  0.0

--- a/Tests/ML/visualizers/test_plot_cross_validation.py
+++ b/Tests/ML/visualizers/test_plot_cross_validation.py
@@ -276,23 +276,15 @@ def test_save_outliers(test_config: PlotCrossValidationConfig,
     assert test_config.run_recovery_id
     dataset_split_metrics = {x: _get_metrics_df(test_config.run_recovery_id, x) for x in [ModelExecutionMode.VAL]}
     save_outliers(test_config, dataset_split_metrics, test_config.outputs_directory)
-    f = f"{ModelExecutionMode.VAL.value}_outliers.txt"
-    assert_text_files_match(full_file=test_config.outputs_directory / f, expected_file=full_ml_test_data_path(f))
-    # Now test without the CSV_INSTITUTION_HEADER and CSV_SERIES_HEADER columns
+    filename = f"{ModelExecutionMode.VAL.value}_outliers.txt"
+    assert_text_files_match(full_file=test_config.outputs_directory / filename, expected_file=full_ml_test_data_path(filename))
+    # Now test without the CSV_INSTITUTION_HEADER and CSV_SERIES_HEADER columns, which will be missing in institutions' environments
     dataset_split_metrics_pruned = {
         x: _get_metrics_df(test_config.run_recovery_id, x).drop(columns=[CSV_INSTITUTION_HEADER, CSV_SERIES_HEADER], errors="ignore") 
         for x in [ModelExecutionMode.VAL]}
     save_outliers(test_config, dataset_split_metrics_pruned, test_config.outputs_directory)
-    actual_outliers_file_path = test_config.outputs_directory / f
-    expected_outliers_file_path = full_ml_test_data_path(f)
-    with actual_outliers_file_path.open() as actual_outliers_file, expected_outliers_file_path.open() as expected_outliers_file:
-        actual_outliers_lines = actual_outliers_file.readlines()
-        expected_outliers_lines = expected_outliers_file.readlines()[:-2]
-        assert len(actual_outliers_lines) == len(expected_outliers_lines)
-        for actual, expected in zip(actual_outliers_lines, expected_outliers_lines):
-            actual = actual.strip()
-            expected = expected.strip()
-            assert actual == expected, content_mismatch(actual, expected)
+    test_data_filename = f"{ModelExecutionMode.VAL.value}_outliers_pruned.txt"
+    assert_text_files_match(full_file=test_config.outputs_directory / filename, expected_file=full_ml_test_data_path(test_data_filename))
 
 
 def test_create_portal_query_for_outliers() -> None:

--- a/Tests/ML/visualizers/test_plot_cross_validation.py
+++ b/Tests/ML/visualizers/test_plot_cross_validation.py
@@ -31,7 +31,7 @@ from InnerEye.ML.visualizers.plot_cross_validation import COL_MODE, \
 from Tests.AfterTraining.test_after_training import get_most_recent_run_id
 from Tests.ML.models.architectures.sequential.test_rnn_classifier import ToyMultiLabelSequenceModel, \
     _get_multi_label_sequence_dataframe
-from Tests.ML.util import assert_text_files_match, get_default_azure_config
+from Tests.ML.util import assert_text_files_match, get_default_azure_config, content_mismatch
 
 
 @pytest.fixture
@@ -277,8 +277,22 @@ def test_save_outliers(test_config: PlotCrossValidationConfig,
     dataset_split_metrics = {x: _get_metrics_df(test_config.run_recovery_id, x) for x in [ModelExecutionMode.VAL]}
     save_outliers(test_config, dataset_split_metrics, test_config.outputs_directory)
     f = f"{ModelExecutionMode.VAL.value}_outliers.txt"
-    assert_text_files_match(full_file=test_config.outputs_directory / f,
-                            expected_file=full_ml_test_data_path(f))
+    assert_text_files_match(full_file=test_config.outputs_directory / f, expected_file=full_ml_test_data_path(f))
+    # Now test without the CSV_INSTITUTION_HEADER and CSV_SERIES_HEADER columns
+    dataset_split_metrics_pruned = {
+        x: _get_metrics_df(test_config.run_recovery_id, x).drop(columns=[CSV_INSTITUTION_HEADER, CSV_SERIES_HEADER], errors="ignore") 
+        for x in [ModelExecutionMode.VAL]}
+    save_outliers(test_config, dataset_split_metrics_pruned, test_config.outputs_directory)
+    actual_outliers_file_path = test_config.outputs_directory / f
+    expected_outliers_file_path = full_ml_test_data_path(f)
+    with actual_outliers_file_path.open() as actual_outliers_file, expected_outliers_file_path.open() as expected_outliers_file:
+        actual_outliers_lines = actual_outliers_file.readlines()
+        expected_outliers_lines = expected_outliers_file.readlines()[:-2]
+        assert len(actual_outliers_lines) == len(expected_outliers_lines)
+        for actual, expected in zip(actual_outliers_lines, expected_outliers_lines):
+            actual = actual.strip()
+            expected = expected.strip()
+            assert actual == expected, content_mismatch(actual, expected)
 
 
 def test_create_portal_query_for_outliers() -> None:

--- a/Tests/ML/visualizers/test_plot_cross_validation.py
+++ b/Tests/ML/visualizers/test_plot_cross_validation.py
@@ -31,7 +31,7 @@ from InnerEye.ML.visualizers.plot_cross_validation import COL_MODE, \
 from Tests.AfterTraining.test_after_training import get_most_recent_run_id
 from Tests.ML.models.architectures.sequential.test_rnn_classifier import ToyMultiLabelSequenceModel, \
     _get_multi_label_sequence_dataframe
-from Tests.ML.util import assert_text_files_match, get_default_azure_config, content_mismatch
+from Tests.ML.util import assert_text_files_match, get_default_azure_config
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixing Issue #423 

_Overview_:

Guarding the call to `create_portal_query_for_outliers` so that the required columns are present, and providing unit test that confirms the change.

_Detail_:

The functions `save_outliers` and `create_portal_query_for_outliers` in `InnerEye.ML.cisualizers.lot_cross_validation` 
 fail if the columns _institutionId_ and _seriesId_ are missing from the data. This PR 

- Augments `create_portal_query_for_outliers` so that it checks for the required columns and raises an informative `ValueError` if they are missing. The function description is updated accordingly.
- Changes `save_outliers` in two ways. If the columns are missing
  - they are not used in the `groupby` which gleans the stats, and
  - the portal query is omitted.
- Test data is provided to check that the revised `save_outliers` produces expected data when the columns are missing
- The unit tests `test_save_outliers` and `test_create_portal_query_for_outliers` in `Tests.ML.visualizers.test_plot_cross_validation` are extended to exercise the new code with columns missing.

_Checklist_:

- [x] Ensure that your PR is small, and implements one change.
- [x] Add unit tests for all functions that you introduced or modified.
- [ ] ~~Run PyCharm's code cleanup tools on your Python files.~~ (I'm using VS Code and have not done this.)
- [x] Link the correct GitHub issue for tracking.
- [x] Update the [Changelog](CHANGELOG.md) file: Describe your change in terms of 
Added/Changed/Removed/... in the "Upcoming" section.
- [x] When merging your PR, replace the default merge message with a description of your PR,
and if needed a motivation why that change was required.
