### PR TITLE
Adding mutually exclusive label check to load_labels_from_dataset_source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ result/
 Tests/logs
 Tests/ML/models/logs
 saved_models/
-Tests/ML/test_data/output
+Tests/ML/test_data/outputs
 Tests/ML/test_data/cxr_test_dataset
 azureml-models
 # Tests

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ result/
 Tests/logs
 Tests/ML/models/logs
 saved_models/
-Tests/ML/test_data/outputs
+Tests/ML/test_data/output
+Tests/ML/test_data/cxr_test_dataset
 azureml-models
 # Tests
 junit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ created.
 
 ### Added
 
+- ([#454](https://github.com/microsoft/InnerEye-DeepLearning/pull/454)) Checking that labels are mutually exclusive.
 - ([#447](https://github.com/microsoft/InnerEye-DeepLearning/pull/447/)) Added a sanity check to ensure there are no
   missing channels, nor missing files. If missing channels in the csv file or filenames associated with channels are
   incorrect, pipeline exits with error report before running training or inference. 

--- a/InnerEye/ML/config.py
+++ b/InnerEye/ML/config.py
@@ -479,6 +479,12 @@ class SegmentationModelBase(ModelConfigBase):
                                                  "patch sampling will be shown. Nifti images and thumbnails for each"
                                                  "of the first N subjects in the training set will be "
                                                  "written to the outputs folder.")
+    #: If true an error is raised in InnerEye.ML.utils.io_util.load_labels_from_dataset_source if the labels are not
+    #: mutually exclusive. Some loss functions (e.g. SoftDice) may produce results on overlapping labels, but others (e.g.
+    #: FocalLoss) will fail with a cryptic error message. Set to false if you are sure that you want to use labels that
+    #: are not mutually exclusive.
+
+    check_exclusive: bool = param.Boolean(True, doc="Raise an error if the segmentation labels are not mutually exclusive.")
 
     def __init__(self, center_size: Optional[TupleInt3] = None,
                  inference_stride_size: Optional[TupleInt3] = None,

--- a/InnerEye/ML/configs/segmentation/HelloWorld.py
+++ b/InnerEye/ML/configs/segmentation/HelloWorld.py
@@ -77,6 +77,9 @@ class HelloWorld(SegmentationModelBase):
             # we define the structure names and colours to use.
             ground_truth_ids_display_names=fg_classes,
             colours=generate_random_colours_list(Random(5), len(fg_classes)),
+
+            # The HelloWorld model uses dummy data with overlapping segmentation labels
+            check_exclusive=False
         )
         self.add_and_validate(kwargs)
 

--- a/InnerEye/ML/dataset/full_image_dataset.py
+++ b/InnerEye/ML/dataset/full_image_dataset.py
@@ -250,7 +250,7 @@ class FullImageDataset(GeneralDataset):
     def get_samples_at_index(self, index: int) -> List[Sample]:
         # load the channels into memory
         ds = self.dataset_sources[self.dataset_indices[index]]
-        samples = [io_util.load_images_from_dataset_source(dataset_source=ds)]  # type: ignore
+        samples = [io_util.load_images_from_dataset_source(dataset_source=ds, check_exclusive=self.args.check_exclusive)]  # type: ignore
         return [Compose3D.apply(self.full_image_sample_transforms, x) for x in samples]
 
     def _load_dataset_sources(self) -> Dict[str, PatientDatasetSource]:

--- a/InnerEye/ML/utils/io_util.py
+++ b/InnerEye/ML/utils/io_util.py
@@ -424,7 +424,7 @@ def load_labels_from_dataset_source(dataset_source: PatientDatasetSource, check_
     labels = np.stack(
         [load_image(gt, ImageDataType.SEGMENTATION.value).image for gt in dataset_source.ground_truth_channels])
 
-    if check_exclusive and not (sum(labels) > 1.).any():  # type: ignore
+    if check_exclusive and (sum(labels) > 1.).any():  # type: ignore
         raise ValueError(f'The labels for patient {dataset_source.metadata.patient_id} are not mutually exclusive. '
                          'Some loss functions (e.g. SoftDice) may produce results on overlapping labels, while others (e.g. FocalLoss) will fail. '
                          'If you are sure that you want to use mutually exclusive labels, '

--- a/Tests/ML/datasets/test_dataset.py
+++ b/Tests/ML/datasets/test_dataset.py
@@ -28,7 +28,6 @@ from InnerEye.ML.utils.split_dataset import DatasetSplits
 
 crop_size = [55, 55, 55]
 
-
 @pytest.fixture
 def num_dataload_workers() -> int:
     """PyTorch support for multiple dataloader workers is flaky on Windows (so return 0)"""

--- a/Tests/ML/test_model_training.py
+++ b/Tests/ML/test_model_training.py
@@ -100,6 +100,7 @@ def _test_model_train(output_dirs: OutputFolderForTests,
     train_config.class_weights = [0.5, 0.25, 0.25]
     train_config.store_dataset_sample = True
     train_config.recovery_checkpoint_save_interval = 1
+    train_config.check_exclusive = False
 
     if machine_has_gpu:
         expected_train_losses = [0.4552919, 0.4548529]

--- a/Tests/ML/utils/test_io_util.py
+++ b/Tests/ML/utils/test_io_util.py
@@ -72,27 +72,36 @@ def test_nii_load_zyx(test_output_dirs: OutputFolderForTests) -> None:
 @pytest.mark.parametrize("ground_truth_channel",
                          [None, known_nii_path, f"{good_h5_path}|segmentation|0|1", good_npy_path])
 @pytest.mark.parametrize("mask_channel", [None, known_nii_path, good_npy_path])
+@pytest.mark.parametrize("check_exclusive", [True, False])
 def test_load_images_from_dataset_source(
         metadata: Optional[str],
         image_channel: Optional[str],
         ground_truth_channel: Optional[str],
-        mask_channel: Optional[str]) -> None:
+        mask_channel: Optional[str],
+        check_exclusive: bool) -> None:
     """
     Test if images are loaded as expected from channels
     """
     # metadata, image and GT channels must be present. Mask is optional
     if None in [metadata, image_channel, ground_truth_channel]:
         with pytest.raises(Exception):
-            _test_load_images_from_channels(metadata, image_channel, ground_truth_channel, mask_channel)
+            _test_load_images_from_channels(metadata, image_channel, ground_truth_channel, mask_channel, check_exclusive)
     else:
-        _test_load_images_from_channels(metadata, image_channel, ground_truth_channel, mask_channel)
+        if check_exclusive:
+            with pytest.raises(ValueError) as mutually_exclusive_labels_error:
+                _test_load_images_from_channels(metadata, image_channel, ground_truth_channel, mask_channel, check_exclusive)
+                error_message = str(mutually_exclusive_labels_error.value)
+                assert 'not mutually exclusive' in error_message
+        else:
+            _test_load_images_from_channels(metadata, image_channel, ground_truth_channel, mask_channel, check_exclusive)
 
 
 def _test_load_images_from_channels(
         metadata: Any,
         image_channel: Any,
         ground_truth_channel: Any,
-        mask_channel: Any) -> None:
+        mask_channel: Any,
+        check_exclusive: bool) -> None:
     """
     Test if images are loaded as expected from channels
     """
@@ -102,7 +111,8 @@ def _test_load_images_from_channels(
             image_channels=[image_channel] * 2,
             ground_truth_channels=[ground_truth_channel] * 4,
             mask_channel=mask_channel
-        )
+        ),
+        check_exclusive=check_exclusive
     )
     if image_channel:
         image_with_header = io_util.load_image(image_channel)

--- a/Tests/ML/utils/test_io_util.py
+++ b/Tests/ML/utils/test_io_util.py
@@ -90,8 +90,7 @@ def test_load_images_from_dataset_source(
         if check_exclusive:
             with pytest.raises(ValueError) as mutually_exclusive_labels_error:
                 _test_load_images_from_channels(metadata, image_channel, ground_truth_channel, mask_channel, check_exclusive)
-                error_message = str(mutually_exclusive_labels_error.value)
-                assert 'not mutually exclusive' in error_message
+            assert 'not mutually exclusive' in str(mutually_exclusive_labels_error.value)
         else:
             _test_load_images_from_channels(metadata, image_channel, ground_truth_channel, mask_channel, check_exclusive)
 


### PR DESCRIPTION
_Issue_

Closes #339 

_Overview_

We need to check that labels are mutually exclusive early, when the labels are loaded from the data source.

_Details_

`load_labels_from_dataset_source` builds up the ground truth tensor from individual binary masks. It sets the background mask correctly, but does not check if each pixel is really only in 1 class. If that assumption is violated, model training may later fail when computing the FocalLoss, and when it fails later the error message does not explain the reason well. So we need to check that the labels are mutually exclusive early, when the labels are loaded from the data source.

Some loss functions (e.g. SoftDice) may cope with overlapping labels so we provide a flag for users to turn off the check, but by default if the labels are not mutually exclusive we now throw a `ValueError` with a suitably explanatory message.

_Checklist_

- [x] Ensure that your PR is small, and implements one change.
- [x] Add unit tests for all functions that you introduced or modified.
- [ ] ~~Run PyCharm's code cleanup tools on your Python files.~~ (I'm using VS Code)
- [x] Link the correct GitHub issue for tracking.
- [x] Update the [Changelog](CHANGELOG.md) file: Describe your change in terms of 
Added/Changed/Removed/... in the "Upcoming" section.
- [x] When merging your PR, replace the default merge message with a description of your PR,
and if needed a motivation why that change was required.
