### PR TITLE
Correct path for ensemble models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ created.
 
 ### Fixed
 
+- ([#472](https://github.com/microsoft/InnerEye-DeepLearning/pull/472)) Correct model path for moving ensemble models.
+
 ### Removed
 
 ### Deprecated

--- a/InnerEye/Scripts/move_model.py
+++ b/InnerEye/Scripts/move_model.py
@@ -10,6 +10,8 @@ import json
 from attr import dataclass
 from azureml.core import Environment, Model, Workspace
 
+from InnerEye.ML.deep_learning_config import FINAL_MODEL_FOLDER, FINAL_ENSEMBLE_MODEL_FOLDER
+
 PYTHON_ENVIRONMENT_NAME = "python_environment_name"
 MODEL_PATH = "MODEL"
 ENVIRONMENT_PATH = "ENVIRONMENT"
@@ -70,7 +72,11 @@ def upload_model(ws: Workspace, config: MoveModelConfig) -> Model:
     with open(model_path / MODEL_JSON, 'r') as f:
         model_dict = json.load(f)
 
-    new_model = Model.register(ws, model_path=str(model_path / "final_model"), model_name=model_dict['name'],
+    # Find the folder containing the final model.
+    final_model_path = model_path / FINAL_MODEL_FOLDER
+    full_model_path = final_model_path if final_model_path.exists() else model_path / FINAL_ENSEMBLE_MODEL_FOLDER
+
+    new_model = Model.register(ws, model_path=str(full_model_path), model_name=model_dict['name'],
                                tags=model_dict['tags'], properties=model_dict['properties'],
                                description=model_dict['description'])
     env = Environment.load_from_directory(str(environment_path))

--- a/Tests/Scripts/test_move_model.py
+++ b/Tests/Scripts/test_move_model.py
@@ -3,25 +3,29 @@
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  ------------------------------------------------------------------------------------------
 
+import pytest
+
 from InnerEye.Azure.azure_config import AzureConfig
 from InnerEye.Common import fixed_paths
 from InnerEye.Common.output_directories import OutputFolderForTests
 from InnerEye.Scripts.move_model import MoveModelConfig, PYTHON_ENVIRONMENT_NAME, move
 
 MODEL_ID = "PassThroughModel:1"
+ENSEMBLE_MODEL_ID = "BasicModel2Epochs:8351"
 
 
-def test_download_and_upload(test_output_dirs: OutputFolderForTests) -> None:
+@pytest.mark.parametrize("model_id", [MODEL_ID, ENSEMBLE_MODEL_ID])
+def test_download_and_upload(model_id: str, test_output_dirs: OutputFolderForTests) -> None:
     """
     Test that downloads and uploads a model to a workspace
     """
     azure_config = AzureConfig.from_yaml(yaml_file_path=fixed_paths.SETTINGS_YAML_FILE,
                                          project_root=fixed_paths.repository_root_directory())
     ws = azure_config.get_workspace()
-    config_download = MoveModelConfig(model_id=MODEL_ID, path=str(test_output_dirs.root_dir), action="download")
+    config_download = MoveModelConfig(model_id=model_id, path=str(test_output_dirs.root_dir), action="download")
     move(ws, config_download)
-    assert (test_output_dirs.root_dir / MODEL_ID.replace(":", "_")).is_dir()
-    config_upload = MoveModelConfig(model_id=MODEL_ID, path=str(test_output_dirs.root_dir), action="upload")
+    assert (test_output_dirs.root_dir / model_id.replace(":", "_")).is_dir()
+    config_upload = MoveModelConfig(model_id=model_id, path=str(test_output_dirs.root_dir), action="upload")
     model = move(ws, config_upload)
     assert model is not None
     assert PYTHON_ENVIRONMENT_NAME in model.tags


### PR DESCRIPTION
Ensemble models are stored with a different path, correct this. Add another test to check download/upload for ensemble models.