### PR TITLE
Partial ground truth inference PR (465) missed two things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ created.
 
 ### Added
 - ([#465](https://github.com/microsoft/InnerEye-DeepLearning/pull/465/)) Adding ability to run segmentation inference
-module in the test data without or partial ground truth files.
+module on test data with partial ground truth files. (Also [522](https://github.com/microsoft/InnerEye-DeepLearning/pull/522).)
 - ([#502](https://github.com/microsoft/InnerEye-DeepLearning/pull/502)) More flags for fine control of when to run inference.
 - ([#492](https://github.com/microsoft/InnerEye-DeepLearning/pull/492)) Adding capability for regression tests for test
 jobs that run in AzureML.

--- a/Tests/ML/test_lightning_containers.py
+++ b/Tests/ML/test_lightning_containers.py
@@ -345,3 +345,4 @@ def test_innereyecontainer_setup_passes_on_allow_incomplete_labels(
     with mock.patch("InnerEye.ML.lightning_base.convert_channels_to_file_paths") as convert_channels_to_file_paths_mock:
         convert_channels_to_file_paths_mock.side_effect = mocked_convert_channels_to_file_paths
         container.setup()
+        convert_channels_to_file_paths_mock.assert_called()

--- a/Tests/ML/test_lightning_containers.py
+++ b/Tests/ML/test_lightning_containers.py
@@ -330,7 +330,6 @@ def test_innereyecontainer_setup_passes_on_allow_incomplete_labels(
     config.set_output_to(test_output_dirs.root_dir)
     config.allow_incomplete_labels = allow_partial_ground_truth
     container = InnerEyeContainer(config)
-    test_done_message = "Stop now, the test has passed."
 
     def mocked_convert_channels_to_file_paths(
             _: List[str],
@@ -338,11 +337,11 @@ def test_innereyecontainer_setup_passes_on_allow_incomplete_labels(
             ___: Path,
             ____: str,
             allow_incomplete_labels: bool) -> Tuple[List[Optional[Path]], str]:
+        paths: List[Optional[Path]] = []
+        failed_channel_info = ''
         assert allow_incomplete_labels == allow_partial_ground_truth
-        raise RuntimeError(test_done_message)
+        return paths, failed_channel_info
 
-    with pytest.raises(RuntimeError) as runtime_error:
-        with mock.patch("InnerEye.ML.lightning_base.convert_channels_to_file_paths") as convert_channels_to_file_paths_mock:
-            convert_channels_to_file_paths_mock.side_effect = mocked_convert_channels_to_file_paths
-            container.setup()
-    assert str(runtime_error.value) == test_done_message
+    with mock.patch("InnerEye.ML.lightning_base.convert_channels_to_file_paths") as convert_channels_to_file_paths_mock:
+        convert_channels_to_file_paths_mock.side_effect = mocked_convert_channels_to_file_paths
+        container.setup()

--- a/docs/move_model.md
+++ b/docs/move_model.md
@@ -5,15 +5,19 @@ training time:
 
 - Model: The model is registered in the AzureML registry and contains the code used at training time and pytorch
   checkpoint
-- Environment: The Azure ML environment used to train the model. This contains the docker image with all the
+- Environment: The Azure ML environment used to train the model. This contains the docker image with all the 
   dependencies that were used for training
 
-If you want to export a model from one Workspace to another you can use the following command to download and upload a model
-from an AzureML workspace. This script does not use settings.yml, it uses interactive authentication, and the workspace specified in the
-parameters. The model will be written to the path in --path parameter with two folders one for the `MODEL` and one for the `ENVIRONMENT` files.
+If you want to export a model from one Workspace to another you can use the following command to download and upload a
+model from an AzureML workspace. This script does not use settings.yml, it uses interactive authentication, and the
+workspace specified in the parameters. The model will be written to the path in --path parameter with two folders one
+for the `MODEL` and one for the `ENVIRONMENT` files.
 
 - Download to
   path: `python InnerEye/Scripts/move_model.py -a download --path ./ --workspace_name "<name>" --resource_group "<name>" --subscription_id "<sub_id>" --model_id "name:version"`
 
 - Upload from
   path: `python InnerEye/Scripts/move_model.py - upload --path ./ --workspace_name "<name>" --resource_group "<name>" --subscription_id "<sub_id>" --model_id "name:version"`
+
+Once in place you may want to run inference on the model with partial test data, i.e. test data from patients for whom
+some of the labels are missing. Normally inference on partial test data would raise an exception. To allow inference to continue over partial test data add the flag `--allow_incomplete_labels` to your inference call, for example `python InnerEye/ML/runner.py --allow_incomplete_labels --train=False --azureml --model=<model_name> --run_recovery_id=<recovery_id>`


### PR DESCRIPTION
There were two things missing/wrong in PR #465:

1.  I forgot to update the documentation.
2. The unit test `test_innereyecontainer_setup_passes_on_allow_incomplete_labels` only tested the first call to the mock function `mocked_convert_channels_to_file_paths`, subsequent calls in the loop were not reached.

Further fixes to #459  

- [ ] ~~Ensure that your PR is small, and implements one change.~~ No, it implements two small changes.
- [x] Add unit tests for all functions that you introduced or modified.
- [ ] ~~Run PyCharm's code cleanup tools on your Python files.~~ I am using VSCode.
- [x] Link the correct GitHub issue for tracking.
- [x] Update the [Changelog](CHANGELOG.md) file: Describe your change in terms of 
Added/Changed/Removed/... in the "Upcoming" section.
- [x] When merging your PR, replace the default merge message with a description of your PR,
and if needed a motivation why that change was required.
