### PR TITLE
(Attempt 2) Enable building an ensemble model from the cross validation checkpoints of a BYO Lightning model

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,15 +2,16 @@
 
 FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0-3
 
+RUN apt-get update
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get -y install --no-install-recommends make
+RUN apt-get -y install gcc git-lfs python3-dev build-essential
+
 # Copy environment.yml (if found) to a temp location so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
 COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
-RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
-    && rm -rf /tmp/conda-tmp
-
-# [Optional] Uncomment this section to install additional OS packages.
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends make
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update --name base --file /tmp/conda-tmp/environment.yml; fi
+RUN rm -rf /tmp/conda-tmp
 
 # [Optional] Uncomment this section to hard code HIML test environment variables into image.
 # ENV HIML_RESOURCE_GROUP="<< YOUR_HIML_RESOURCE_GROUP >>"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/python-3-miniconda/.devcontainer/base.Dockerfile
+
+FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0-3
+
+# Copy environment.yml (if found) to a temp location so we update the environment. Also
+# copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
+COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
+    && rm -rf /tmp/conda-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends make
+
+# [Optional] Uncomment this section to hard code HIML test environment variables into image.
+# ENV HIML_RESOURCE_GROUP="<< YOUR_HIML_RESOURCE_GROUP >>"
+# ENV HIML_SUBSCRIPTION_ID="<< YOUR_HIML_SUBSCRIPTION_ID >>"
+# ENV HIML_WORKSPACE_NAME="<< YOUR_HIML_WORKSPACE_NAME >>"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0-3
 
 RUN apt-get update
-ENV DEBIAN_FRONTEND=noninteractive
+RUN export DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y install --no-install-recommends make
 RUN apt-get -y install gcc git-lfs python3-dev build-essential
 
@@ -12,6 +12,10 @@ RUN apt-get -y install gcc git-lfs python3-dev build-essential
 COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
 RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update --name base --file /tmp/conda-tmp/environment.yml; fi
 RUN rm -rf /tmp/conda-tmp
+# N.B. Despite the previous lines I still needed to run
+#     conda update --name base conda --channel anaconda
+#     conda env create --file environment.yml
+# manually in the container after it started. TODO: Fix that.
 
 # [Optional] Uncomment this section to hard code HIML test environment variables into image.
 # ENV HIML_RESOURCE_GROUP="<< YOUR_HIML_RESOURCE_GROUP >>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/python-3-miniconda
+{
+	"name": "InnerEye",
+	"build": { 
+		"context": "..",
+		"dockerfile": "Dockerfile",
+		"args": {}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"python.pythonPath": "/opt/conda/bin/python",
+		"python.languageServer": "Pylance",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python",
+		"ms-python.vscode-pylance"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "python --version",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/noop.txt
+++ b/.devcontainer/noop.txt
@@ -1,0 +1,3 @@
+This file is copied into the container along with environment.yml* from the
+parent folder. This is done to prevent the Dockerfile COPY instruction from 
+failing if no environment.yml is found.

--- a/.gitignore
+++ b/.gitignore
@@ -129,9 +129,6 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
-# other
-.vscode/
-
 /InnerEye/ML/src/aml_config
 *.exe
 *.suo

--- a/.vscode/.pylintrc
+++ b/.vscode/.pylintrc
@@ -1,0 +1,2 @@
+disable=
+    ungrouped-imports

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,41 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "InnerEye: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "env": {"PYTHONPATH": "${workspaceRoot}"},
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "InnerEye: Cross Validation",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "env": {"PYTHONPATH": "${workspaceRoot}"},
+            "args": ["--model", "HelloContainer", "--number_of_cross_validation_splits=5"],
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "InnerEye: AzureML Cross Validation",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "env": {"PYTHONPATH": "${workspaceRoot}"},
+            "args": ["--model", "HelloContainer", "--number_of_cross_validation_splits=5", "--azureml=True"],
+            "console": "integratedTerminal"
+        },
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,46 @@
+{
+    "python.envFile": "${workspaceFolder}/.vscode/.env",
+    "python.linting.pylintEnabled": true,
+    "python.linting.pylintArgs": [
+        "--max-line-length=120",
+        "--rcfile=${workspaceFolder}/.vscode/.pylintrc"
+    ],
+    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Args": [
+        "--config=${workspaceFolder}/.flake8",
+    ],
+    "python.linting.mypyEnabled": true,
+    "python.linting.mypyArgs": [
+        "--config-file=${workspaceFolder}/mypy.ini"
+    ],
+    "python.linting.pycodestyleEnabled": true,
+    "python.linting.pycodestyleArgs": [
+        "--max-line-length=120",
+        "--show-source",
+        "--show-pep8"
+    ],
+    "python.formatting.provider": "black",
+    "python.formatting.blackArgs": [
+        "--line-length=120"
+    ],
+    "python.sortImports.args": ["-l", "120"],
+    "python.testing.pytestArgs": [
+        "${workspaceFolder}/Tests/"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "[python]": {
+        "editor.rulers": [120],
+        "rewrap.autoWrap.enabled": true,
+    },
+    "terminal.integrated.env.linux": {
+        "PYTHONPATH": "${workspaceFolder}",
+    },
+    "terminal.integrated.env.osx": {
+        "PYTHONPATH": "${workspaceFolder}",
+    },
+    "terminal.integrated.env.windows": {
+        "PYTHONPATH": "${workspaceFolder}",
+    },
+}

--- a/InnerEye/ML/lightning_container.py
+++ b/InnerEye/ML/lightning_container.py
@@ -50,14 +50,14 @@ class InnerEyeInference(abc.ABC):
         """
         pass
 
-    def on_inference_start_dataset(self, dataset_split: ModelExecutionMode, is_ensemble_model: bool) -> None:
+    def on_inference_start_dataset(self, dataset_split: ModelExecutionMode, is_ensemble_model: bool = False) -> None:
         """
         Runs initialization for inference, when starting inference on a new dataset split (train/val/test).
         Depending on the settings, this can be called anywhere between 0 (no inference at all) to 3 times (inference
         on all of train/val/test split).
         :param dataset_split: Indicates whether the item comes from the training, validation or test set.
-        :param is_ensemble_model: If False, the model_outputs come from an individual model. If True, the model
-        outputs come from multiple models. Use to change where the metrics are saved.
+        :param is_ensemble_model: If False (the default), the model_outputs come from an individual model. If True, the
+        model outputs come from multiple models. Use this to change where the metrics are saved for ensemble models.
         """
         pass
 

--- a/InnerEye/ML/lightning_container.py
+++ b/InnerEye/ML/lightning_container.py
@@ -43,21 +43,23 @@ class InnerEyeInference(abc.ABC):
     model.on_inference_end()
     """
 
-    def on_inference_start(self) -> None:
+    def on_inference_start(self, is_ensemble_model: bool = False) -> None:
         """
         Runs initialization for everything that inference might require. This can initialize
         output files, set up metric computation, etc. This is run only once.
+        :param is_ensemble_model: If False (the default), the model_output posteriors come from an individual model,
+        i.e. this model. If True, the model outputs come from multiple models and this model has been choosen to process
+        them (typically because it is at index zero in the list of models which make up the ensemble). You should use
+        this to change where the metrics are saved for ensemble models.
         """
         pass
 
-    def on_inference_start_dataset(self, dataset_split: ModelExecutionMode, is_ensemble_model: bool = False) -> None:
+    def on_inference_start_dataset(self, dataset_split: ModelExecutionMode) -> None:
         """
         Runs initialization for inference, when starting inference on a new dataset split (train/val/test).
         Depending on the settings, this can be called anywhere between 0 (no inference at all) to 3 times (inference
         on all of train/val/test split).
         :param dataset_split: Indicates whether the item comes from the training, validation or test set.
-        :param is_ensemble_model: If False (the default), the model_outputs come from an individual model. If True, the
-        model outputs come from multiple models. Use this to change where the metrics are saved for ensemble models.
         """
         pass
 

--- a/InnerEye/ML/lightning_container.py
+++ b/InnerEye/ML/lightning_container.py
@@ -50,29 +50,30 @@ class InnerEyeInference(abc.ABC):
         """
         pass
 
-    def on_inference_epoch_start(self, dataset_split: ModelExecutionMode, is_ensemble_model: bool) -> None:
+    def on_inference_start_dataset(self, dataset_split: ModelExecutionMode, is_ensemble_model: bool) -> None:
         """
         Runs initialization for inference, when starting inference on a new dataset split (train/val/test).
         Depending on the settings, this can be called anywhere between 0 (no inference at all) to 3 times (inference
         on all of train/val/test split).
         :param dataset_split: Indicates whether the item comes from the training, validation or test set.
         :param is_ensemble_model: If False, the model_outputs come from an individual model. If True, the model
-        outputs come from multiple models.
+        outputs come from multiple models. Use to change where the metrics are saved.
         """
         pass
 
-    def inference_step(self, batch: Any, batch_idx: int, model_output: torch.Tensor) -> None:
+    def record_posteriors(self, batch: Any, batch_idx: int, posteriors: torch.Tensor) -> None:
         """
         This hook is called when the model has finished making a prediction. It can write the results to a file,
         or compute metrics and store them.
         :param batch: The batch of data for which the model made a prediction.
-        :param model_output: The model outputs. This would usually be a torch.Tensor, but can be any datatype.
+        :param batch: The index of the batch.
+        :param posteriors: The posteriors output by the model.
         """
         # We don't want abstract methods here, it avoids class creation for unit tests, and we also want this
         # method to be left optional (it should be possible to also use Lightning's native test_step method)
         raise NotImplementedError("Method on_inference_start must be overwritten in a derived class.")
 
-    def on_inference_epoch_end(self) -> None:
+    def on_inference_end_dataset(self) -> None:
         """
         Called when the inference on one of the dataset splits (train/val/test) has finished.
         Depending on the settings, this can be called anywhere between 0 (no inference at all) to 3 times (inference

--- a/Tests/ML/configs/lightning_test_containers.py
+++ b/Tests/ML/configs/lightning_test_containers.py
@@ -127,18 +127,18 @@ class DummyRegression(DummyRegressionPlainLightning, InnerEyeInference):
         self.log("loss", loss, on_epoch=True, on_step=True)
         return loss
 
-    def on_inference_start(self) -> None:
+    def on_inference_start(self, is_ensemble_model: bool = False) -> None:
         Path("on_inference_start.txt").touch()
         self.inference_mse: Dict[ModelExecutionMode, float] = {}
 
-    def on_inference_epoch_start(self, dataset_split: ModelExecutionMode, is_ensemble_model: bool) -> None:
+    def on_inference_start_dataset(self, dataset_split: ModelExecutionMode) -> None:
         self.dataset_split = dataset_split
         Path(f"on_inference_start_{self.dataset_split.value}.txt").touch()
         self.mse = MeanSquaredError()
 
-    def inference_step(self, item: Tuple[Tensor, Tensor], batch_idx: int, model_output: torch.Tensor) -> None:
+    def record_posteriors(self, batch: Any, batch_idx: int, posteriors: torch.Tensor) -> None:
         input, target = item
-        prediction = self.forward(input)
+        prediction = self.forward(batch)
         self.mse(prediction, target)
         with Path(f"inference_step_{self.dataset_split.value}.txt").open(mode="a") as f:
             f.write(f"{prediction.item()},{target.item()}\n")


### PR DESCRIPTION
Closing #527 

The method MLRunner.run_inference_for_lightning_models takes a list of checkpoint paths as an argument, but then makes sure that there is only one used ([here](https://github.com/microsoft/InnerEye-DeepLearning/blob/3fc71b847e9dd4ad9d0b070722558064647d95a2/InnerEye/ML/run_ml.py#L444-L445)):

```
    if len(checkpoint_paths) != 1:
        raise ValueError(f"This method expects exactly 1 checkpoint for inference, but got {len(checkpoint_paths)}")
```

We want to change this so that the checkpoints gleaned from a BYOL cross validation run can be used as an ensemble model.

- This will use the methods defined in the InnerEyeInference abstract class. We expect that these methods are sufficient, but an extension or redesign may be required.
- Use the simple linear regression model as the basis of an exemplar.
- It would be great to use another, more realistic model, e.g. the Single Cell model?

[AB#4219](https://innereye.visualstudio.com/60ce1777-00d6-4015-82bc-488a0c00202f/_workitems/edit/4219)