### PR TITLE
Use SSLEncoder when building model in CovidModel config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ in inference-only runs when using lightning containers.
 - ([#553](https://github.com/microsoft/InnerEye-DeepLearning/pull/553)) Fix incomplete test data module setup in Lightning inference.
 - ([#557](https://github.com/microsoft/InnerEye-DeepLearning/pull/557)) Fix issue where learning rate was not set
   correctly in the SimCLR module
+- ([#558](https://github.com/microsoft/InnerEye-DeepLearning/pull/558)) Fix issue with the CovidModel config where model
+  weights from a finetuning run were incompatible with the model architecture created for non-finetuning runs.
 
 ### Removed
 

--- a/InnerEye/ML/configs/classification/CovidModel.py
+++ b/InnerEye/ML/configs/classification/CovidModel.py
@@ -19,10 +19,10 @@ from torchvision.transforms import Compose
 from InnerEye.Common.common_util import ModelProcessing, get_best_epoch_results_path
 from InnerEye.Common.metrics_constants import LoggingColumns
 
+from InnerEye.ML.SSL.encoders import SSLEncoder
 from InnerEye.ML.SSL.lightning_containers.ssl_container import EncoderName
-
 from InnerEye.ML.SSL.lightning_modules.ssl_classifier_module import SSLClassifier
-from InnerEye.ML.SSL.utils import create_ssl_encoder, create_ssl_image_classifier, load_yaml_augmentation_config
+from InnerEye.ML.SSL.utils import create_ssl_image_classifier, load_yaml_augmentation_config
 from InnerEye.ML.augmentations.transform_pipeline import create_cxr_transforms_from_config
 from InnerEye.ML.common import ModelExecutionMode
 
@@ -158,7 +158,7 @@ class CovidModel(ScalarModelBase):
                 freeze_encoder=self.freeze_encoder)
 
         else:
-            encoder = create_ssl_encoder(encoder_name=EncoderName.densenet121.value)
+            encoder = SSLEncoder(encoder_name=EncoderName.densenet121.value)
             model = SSLClassifier(num_classes=self.num_classes,
                                   encoder=encoder,
                                   freeze_encoder=self.freeze_encoder,


### PR DESCRIPTION
Bug fix: In the CovidModel config, use an object of type `SSLEncoder` when creating a new model instead of calling `create_ssl_encoder`. Without this model weights from a finetuning run will be incompatible with the model architecture created for non-finetuning runs.