### PR TITLE
Allow overriding AzureML experiment name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ jobs that run in AzureML.
   `NIH_COVID_BYOL` to specify the name of the SSL training dataset.
 - ([#560](https://github.com/microsoft/InnerEye-DeepLearning/pull/560)) Added pre-commit hooks.
 - ([#559](https://github.com/microsoft/InnerEye-DeepLearning/pull/559)) Adding the accompanying code for the ["Active label cleaning: Improving dataset quality under resource constraints"](https://arxiv.org/abs/2109.00574) paper. The code can be found in the [InnerEye-DataQuality](InnerEye-DataQuality/README.md) subfolder. It provides tools for training noise robust models, running label cleaning simulation and loading our label cleaning benchmark datasets.
+- ([#583](https://github.com/microsoft/InnerEye-DeepLearning/pull/583)) Allow overriding `experiment_name` for AzureML runs.
 
 ### Changed
 - ([#531](https://github.com/microsoft/InnerEye-DeepLearning/pull/531)) Updated PL to 1.3.8, torchmetrics and pl-bolts and changed relevant metrics and SSL code API.

--- a/InnerEye/ML/deep_learning_config.py
+++ b/InnerEye/ML/deep_learning_config.py
@@ -222,6 +222,9 @@ class WorkflowParams(param.Parameterized):
     local_weights_path: List[Path] = param.List(default=[], class_=Path,
                                                 doc="A list of checkpoints paths to use for inference, "
                                                     "when the job is running outside Azure.")
+    experiment_name: str = param.String(default="",
+                                        doc="If provided, overrides the default AzureML experiment name "
+                                            "based on the current Git branch.")
     model_id: str = param.String(default="",
                                  doc="A model id string in the form 'model name:version' "
                                      "to use a registered model for inference.")

--- a/InnerEye/ML/runner.py
+++ b/InnerEye/ML/runner.py
@@ -296,6 +296,8 @@ class Runner:
                 if not self.azure_config.cluster:
                     raise ValueError("self.azure_config.cluster not set, but we need a compute_cluster_name to submit"
                                      "the script to run in AzureML")
+                experiment_name = self.lightning_container.experiment_name \
+                    or create_experiment_name(self.azure_config)
                 azure_run_info = submit_to_azure_if_needed(
                     entry_script=source_config.entry_script,
                     snapshot_root_directory=source_config.root_folder,
@@ -305,7 +307,7 @@ class Runner:
                     compute_cluster_name=self.azure_config.cluster,
                     environment_variables=source_config.environment_variables,
                     default_datastore=self.azure_config.azureml_datastore,
-                    experiment_name=to_azure_friendly_string(create_experiment_name(self.azure_config)),
+                    experiment_name=to_azure_friendly_string(experiment_name),
                     max_run_duration=self.azure_config.max_run_duration,
                     input_datasets=input_datasets,
                     num_nodes=self.azure_config.num_nodes,


### PR DESCRIPTION
Currently there is no way to override the name of an AzureML experiment created with the InnerEye runner, which uses the branch name by default. This PR enables one to customise the experiment name from a `LightningContainer` or command line.
