### PR TITLE
Use PIL.PngImagePlugin to load pngs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ jobs that run in AzureML.
 - ([#559](https://github.com/microsoft/InnerEye-DeepLearning/pull/559)) Adding the accompanying code for the ["Active label cleaning: Improving dataset quality under resource constraints"](https://arxiv.org/abs/2109.00574) paper. The code can be found in the [InnerEye-DataQuality](InnerEye-DataQuality/README.md) subfolder. It provides tools for training noise robust models, running label cleaning simulation and loading our label cleaning benchmark datasets.
 
 ### Changed
+- ([#588](https://github.com/microsoft/InnerEye-DeepLearning/pull/588)) Replace SciPy with matplotlib to load png files.
 - ([#576](https://github.com/microsoft/InnerEye-DeepLearning/pull/576)) The console output is no longer written to stdout.txt because AzureML handles that better now
 - ([#531](https://github.com/microsoft/InnerEye-DeepLearning/pull/531)) Updated PL to 1.3.8, torchmetrics and pl-bolts and changed relevant metrics and SSL code API.
 - ([#555](https://github.com/microsoft/InnerEye-DeepLearning/pull/555)) Make the SSLContainer compatible with new datasets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ jobs that run in AzureML.
   hook to enable overriding `AzureConfig` parameters from a container (e.g. `experiment_name`, `cluster`, `num_nodes`).
 
 ### Changed
-- ([#588](https://github.com/microsoft/InnerEye-DeepLearning/pull/588)) Replace SciPy with matplotlib to load png files.
+- ([#588](https://github.com/microsoft/InnerEye-DeepLearning/pull/588)) Replace SciPy with PIL.PngImagePlugin.PngImageFile to load png files.
 - ([#576](https://github.com/microsoft/InnerEye-DeepLearning/pull/576)) The console output is no longer written to stdout.txt because AzureML handles that better now
 - ([#531](https://github.com/microsoft/InnerEye-DeepLearning/pull/531)) Updated PL to 1.3.8, torchmetrics and pl-bolts and changed relevant metrics and SSL code API.
 - ([#555](https://github.com/microsoft/InnerEye-DeepLearning/pull/555)) Make the SSLContainer compatible with new datasets

--- a/InnerEye/ML/utils/io_util.py
+++ b/InnerEye/ML/utils/io_util.py
@@ -12,6 +12,7 @@ from typing import Dict, Generic, Iterable, List, Optional, Tuple, Type, TypeVar
 
 import SimpleITK as sitk
 import h5py
+import matplotlib.image as mpimg
 import numpy as np
 import pandas as pd
 import pydicom as dicom
@@ -495,8 +496,15 @@ def load_image(path: PathOrString, image_type: Optional[Type] = float) -> ImageW
             header = get_unit_image_header()
             return ImageWithHeader(image, header)
     elif is_png(path):
-        import imageio
-        image = imageio.imread(path).astype(np.float)
+        # https://matplotlib.org/stable/api/image_api.html#matplotlib.image.imread
+        # numpy_array is a numpy.array of shape: (H, W), (H, W, 3), or (H, W, 4)
+        # where H = height, W = width
+        nd = mpimg.imread(path)
+        if len(nd.shape) == 2:
+            # if loaded a greyscale image, then it is of shape (H, W) so add in an extra axis
+            nd = np.expand_dims(nd, 2)
+        # transpose to shape (C, H, W)
+        image = np.transpose(nd, (2, 0, 1))
         header = get_unit_image_header()
         return ImageWithHeader(image, header)
     raise ValueError(f"Invalid file type {path}")

--- a/InnerEye/ML/utils/io_util.py
+++ b/InnerEye/ML/utils/io_util.py
@@ -15,6 +15,7 @@ import h5py
 import matplotlib.image as mpimg
 import numpy as np
 import pandas as pd
+import PIL.PngImagePlugin
 import pydicom as dicom
 import torch
 from numpy.lib.npyio import NpzFile
@@ -496,15 +497,8 @@ def load_image(path: PathOrString, image_type: Optional[Type] = float) -> ImageW
             header = get_unit_image_header()
             return ImageWithHeader(image, header)
     elif is_png(path):
-        # https://matplotlib.org/stable/api/image_api.html#matplotlib.image.imread
-        # numpy_array is a numpy.array of shape: (H, W), (H, W, 3), or (H, W, 4)
-        # where H = height, W = width
-        nd = mpimg.imread(path)
-        if len(nd.shape) == 2:
-            # if loaded a greyscale image, then it is of shape (H, W) so add in an extra axis
-            nd = np.expand_dims(nd, 2)
-        # transpose to shape (C, H, W)
-        image = np.transpose(nd, (2, 0, 1))
+        with PIL.PngImagePlugin.PngImageFile(path) as pil_png:
+            image = np.asarray(pil_png, np.float)
         header = get_unit_image_header()
         return ImageWithHeader(image, header)
     raise ValueError(f"Invalid file type {path}")

--- a/InnerEye/ML/utils/io_util.py
+++ b/InnerEye/ML/utils/io_util.py
@@ -12,7 +12,6 @@ from typing import Dict, Generic, Iterable, List, Optional, Tuple, Type, TypeVar
 
 import SimpleITK as sitk
 import h5py
-import matplotlib.image as mpimg
 import numpy as np
 import pandas as pd
 import PIL.PngImagePlugin

--- a/Tests/ML/utils/test_io_util.py
+++ b/Tests/ML/utils/test_io_util.py
@@ -9,11 +9,14 @@ from typing import Any, Optional, Tuple
 from unittest import mock
 import zipfile
 
+import imageio
+import PIL.PngImagePlugin
 import SimpleITK as sitk
 import numpy as np
 import pydicom
 import pytest
 import torch
+from PIL import Image
 from skimage.transform import resize
 
 from InnerEye.Common.fixed_paths_for_tests import full_ml_test_data_path
@@ -278,6 +281,7 @@ def write_test_dicom(array: np.ndarray, path: Path, is_monochrome2: bool = True,
         ds.BitsStored = bits_stored
     ds.save_as(path)
 
+
 @pytest.mark.parametrize("is_signed", [True, False])
 @pytest.mark.parametrize("is_monochrome2", [True, False])
 def test_load_dicom_image_ones(test_output_dirs: OutputFolderForTests,
@@ -405,8 +409,8 @@ def test_load_and_stack_with_crop() -> None:
     # values of 1.0 are in the image
     image = np.zeros(image_size)
     image[center_start[0]:center_start[0] + crop_shape[0],
-    center_start[1]:center_start[1] + crop_shape[1],
-    center_start[2]:center_start[2] + crop_shape[2]] = 1
+          center_start[1]:center_start[1] + crop_shape[1],
+          center_start[2]:center_start[2] + crop_shape[2]] = 1
     segmentation = image * 2
     mock_return = ImageAndSegmentations(image, segmentation)
     with mock.patch("InnerEye.ML.utils.io_util.load_image_in_known_formats", return_value=mock_return):
@@ -689,3 +693,32 @@ def test_zip_random_dicom_series(test_output_dirs: OutputFolderForTests) -> None
     # GetSize returns (width, height, depth)
     assert loaded_image.GetSize() == reverse_tuple_float3(test_shape)
     assert loaded_image.GetSpacing() == test_spacing
+
+
+def test_load_png_images(test_output_dirs: OutputFolderForTests) -> None:
+    """
+    Test load of png image files in a variety of formats using SciPy and PIL.PngImagePlugin
+    """
+    def save_and_reload_image(data: np.array,  # type: ignore
+                              mode: str) -> None:
+        path = test_output_dirs.root_dir / f"{mode}.png"
+        image = Image.fromarray(data, mode=mode)
+        image.save(path)
+
+        scipy_image = imageio.imread(path).astype(np.float)
+        assert scipy_image.dtype == np.float  # type: ignore
+        assert np.array_equal(data, scipy_image)
+
+        with PIL.PngImagePlugin.PngImageFile(path) as pil_png:
+            pil_image = np.asarray(pil_png, np.float)
+        assert pil_image.dtype == np.float  # type: ignore
+        assert np.array_equal(data, pil_image)
+
+    data_l = np.random.randint(2**8, size=(300, 200), dtype=np.uint8)
+    save_and_reload_image(data_l, 'L')
+
+    data_rgb = np.random.randint(2**8, size=(300, 200, 3), dtype=np.uint8)
+    save_and_reload_image(data_rgb, 'RGB')
+
+    data_rgba = np.random.randint(2**8, size=(300, 200, 4), dtype=np.uint8)
+    save_and_reload_image(data_rgba, 'RGBA')

--- a/Tests/ML/utils/test_io_util.py
+++ b/Tests/ML/utils/test_io_util.py
@@ -10,7 +10,6 @@ from unittest import mock
 import zipfile
 
 import imageio
-import PIL.PngImagePlugin
 import SimpleITK as sitk
 import numpy as np
 import pydicom

--- a/Tests/ML/utils/test_io_util.py
+++ b/Tests/ML/utils/test_io_util.py
@@ -709,10 +709,9 @@ def test_load_png_images(test_output_dirs: OutputFolderForTests) -> None:
         assert scipy_image.dtype == np.float  # type: ignore
         assert np.array_equal(data, scipy_image)
 
-        with PIL.PngImagePlugin.PngImageFile(path) as pil_png:
-            pil_image = np.asarray(pil_png, np.float)
-        assert pil_image.dtype == np.float  # type: ignore
-        assert np.array_equal(data, pil_image)
+        image_with_header = io_util.load_image(path)
+        assert image_with_header.image.dtype == np.float  # type: ignore
+        assert np.array_equal(data, image_with_header.image)
 
     data_l = np.random.randint(2**8, size=(300, 200), dtype=np.uint8)
     save_and_reload_image(data_l, 'L')


### PR DESCRIPTION
Replace using SciPy with PIL.PngImagePlugin  to load png files. SciPy does end up calling this plugin, but there's a lot of overhead.

Please follow the guidelines for PRs contained [here](docs/pull_requests.md). Checklist:

- [x] Ensure that your PR is small, and implements one change.
- [x] Add unit tests for all functions that you introduced or modified.
- [ ] Run PyCharm's code cleanup tools on your Python files.
- [x] Link the correct GitHub issue for tracking.
- [x] Update the [Changelog](CHANGELOG.md) file: Describe your change in terms of 
Added/Changed/Removed/... in the "Upcoming" section.
- [ ] When merging your PR, replace the default merge message with a description of your PR,
and if needed a motivation why that change was required.
