### PR TITLE
Enable overriding AzureConfig parameters from a LightningContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ jobs that run in AzureML.
   `NIH_COVID_BYOL` to specify the name of the SSL training dataset.
 - ([#560](https://github.com/microsoft/InnerEye-DeepLearning/pull/560)) Added pre-commit hooks.
 - ([#559](https://github.com/microsoft/InnerEye-DeepLearning/pull/559)) Adding the accompanying code for the ["Active label cleaning: Improving dataset quality under resource constraints"](https://arxiv.org/abs/2109.00574) paper. The code can be found in the [InnerEye-DataQuality](InnerEye-DataQuality/README.md) subfolder. It provides tools for training noise robust models, running label cleaning simulation and loading our label cleaning benchmark datasets.
+- ([#589](https://github.com/microsoft/InnerEye-DeepLearning/pull/589)) Add `LightningContainer.update_azure_config()`
+  hook to enable overriding `AzureConfig` parameters from a container (e.g. `experiment_name`, `cluster`, `num_nodes`).
 
 ### Changed
 - ([#576](https://github.com/microsoft/InnerEye-DeepLearning/pull/576)) The console output is no longer written to stdout.txt because AzureML handles that better now

--- a/InnerEye/ML/lightning_container.py
+++ b/InnerEye/ML/lightning_container.py
@@ -13,6 +13,7 @@ from torch.optim import Optimizer
 from torch.optim.lr_scheduler import _LRScheduler
 from azureml.core import ScriptRunConfig
 from azureml.train.hyperdrive import GridParameterSampling, HyperDriveConfig, PrimaryMetricGoal, choice
+from InnerEye.Azure.azure_config import AzureConfig
 
 from InnerEye.Azure.azure_util import CROSS_VALIDATION_SPLIT_INDEX_TAG_KEY
 from InnerEye.Common.generic_parsing import GenericConfig, create_from_matching_params
@@ -212,6 +213,14 @@ class LightningContainer(GenericConfig,
         Parameter search is not implemented. It should be implemented in a sub class if needed.
         """
         raise NotImplementedError("Parameter search is not implemented. It should be implemented in a sub class if needed.")
+
+    def update_azure_config(self, azure_config: AzureConfig) -> None:
+        """
+        This method allows overriding AzureConfig parameters from within a LightningContainer.
+        It is called right after the AzureConfig and container are initialised.
+        :param azure_config: The initialised AzureConfig whose parameters to override in-place.
+        """
+        pass
 
     def create_report(self) -> None:
         """

--- a/InnerEye/ML/lightning_container.py
+++ b/InnerEye/ML/lightning_container.py
@@ -218,6 +218,11 @@ class LightningContainer(GenericConfig,
         """
         This method allows overriding AzureConfig parameters from within a LightningContainer.
         It is called right after the AzureConfig and container are initialised.
+        Be careful when using class parameters to override these values. If the parameter names clash,
+        CLI values will be consumed by the AzureConfig, but container parameters will keep their defaults.
+        This can be avoided by always using unique parameter names.
+        Also note that saving a reference to `azure_config` and updating its attributes at any other
+        point may lead to unexpected behaviour.
         :param azure_config: The initialised AzureConfig whose parameters to override in-place.
         """
         pass

--- a/InnerEye/ML/runner.py
+++ b/InnerEye/ML/runner.py
@@ -186,6 +186,10 @@ class Runner:
             self.lightning_container = InnerEyeContainer(config_or_container)
         else:
             raise ValueError(f"Don't know how to handle a loaded configuration of type {type(config_or_container)}")
+
+        # Allow overriding AzureConfig params from within the container.
+        self.lightning_container.update_azure_config(self.azure_config)
+
         if azure_config.extra_code_directory:
             exist = "exists" if Path(azure_config.extra_code_directory).exists() else "does not exist"
             logging.info(f"extra_code_directory is {azure_config.extra_code_directory}, which {exist}")


### PR DESCRIPTION
Currently, the only ways to set `AzureConfig` parameters are from either a YAML file or command line. However, there are parameters that would be convenient to set separately and consistently for individual model containers (e.g. `experiment_name`, `cluster`, `num_nodes`). This PR adds `LightningContainer.update_azure_config()` to modify the `AzureConfig` in-place after instantiation.

[This PR supersedes the less generic #583]