### PR TITLE
Enabling distributed training for SSL online evaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ in inference-only runs when using lightning containers.
 - ([#558](https://github.com/microsoft/InnerEye-DeepLearning/pull/558)) Fix issue with the CovidModel config where model
   weights from a finetuning run were incompatible with the model architecture created for non-finetuning runs.
 - ([#604](https://github.com/microsoft/InnerEye-DeepLearning/pull/604)) Fix issue where runs on a VM would download the dataset even when a local dataset is provided.
+- ([#612](https://github.com/microsoft/InnerEye-DeepLearning/pull/612)) SSL online evaluator was not doing distributed training
 
 ### Removed
 

--- a/InnerEye/ML/SSL/lightning_modules/ssl_online_evaluator.py
+++ b/InnerEye/ML/SSL/lightning_modules/ssl_online_evaluator.py
@@ -17,7 +17,7 @@ from torchmetrics import Metric
 
 from InnerEye.ML.SSL.utils import SSLDataModuleType
 from InnerEye.ML.lightning_metrics import Accuracy05, AreaUnderPrecisionRecallCurve, AreaUnderRocCurve
-from InnerEye.ML.utils.model_util import set_model_to_eval_mode
+from InnerEye.ML.utils.layer_util import set_model_to_eval_mode
 from health_ml.utils import log_on_epoch
 
 BatchType = Union[Dict[SSLDataModuleType, Any], Any]

--- a/InnerEye/ML/SSL/lightning_modules/ssl_online_evaluator.py
+++ b/InnerEye/ML/SSL/lightning_modules/ssl_online_evaluator.py
@@ -86,8 +86,6 @@ class SSLOnlineEvaluatorInnerEye(SSLOnlineEvaluator):
         if accelerator.is_distributed:
             if accelerator.use_ddp:
                 self.evaluator = DistributedDataParallel(self.evaluator, device_ids=[pl_module.device])  # type: ignore
-            elif accelerator.use_dp:
-                self.evaluator = DataParallel(self.evaluator, device_ids=[pl_module.device])  # type: ignore
             else:
                 rank_zero_warn("This type of distributed accelerator is not supported. "
                                "The online evaluator will not synchronize across GPUs.")

--- a/InnerEye/ML/SSL/lightning_modules/ssl_online_evaluator.py
+++ b/InnerEye/ML/SSL/lightning_modules/ssl_online_evaluator.py
@@ -9,21 +9,24 @@ import pytorch_lightning as pl
 import torch
 from pl_bolts.callbacks.ssl_online import SSLOnlineEvaluator
 from pl_bolts.models.self_supervised.evaluator import SSLEvaluator
+from pytorch_lightning.utilities import rank_zero_warn
 from torch import Tensor as T
-from health_ml.utils import log_on_epoch
-from torch.nn import functional as F
+from torch.nn import DataParallel, functional as F
+from torch.nn.parallel import DistributedDataParallel
 from torchmetrics import Metric
 
 from InnerEye.ML.SSL.utils import SSLDataModuleType
 from InnerEye.ML.lightning_metrics import Accuracy05, AreaUnderPrecisionRecallCurve, AreaUnderRocCurve
+from InnerEye.ML.utils.model_util import set_model_to_eval_mode
+from health_ml.utils import log_on_epoch
 
 BatchType = Union[Dict[SSLDataModuleType, Any], Any]
 
-OPTIMIZER_STATE_NAME = "evaluator_optimizer"
-EVALUATOR_STATE_NAME = "evaluator_weights"
-
 
 class SSLOnlineEvaluatorInnerEye(SSLOnlineEvaluator):
+    OPTIMIZER_STATE_NAME = "evaluator_optimizer"
+    EVALUATOR_STATE_NAME = "evaluator_weights"
+
     def __init__(self,
                  learning_rate: float,
                  class_weights: Optional[torch.Tensor] = None,
@@ -47,11 +50,11 @@ class SSLOnlineEvaluatorInnerEye(SSLOnlineEvaluator):
                                           Accuracy05()] \
             if self.num_classes == 2 else [Accuracy05()]
         self.class_weights = class_weights
-        self.non_linear_evaluator = SSLEvaluator(n_input=self.z_dim,
-                                                 n_classes=self.num_classes,
-                                                 p=self.drop_p,
-                                                 n_hidden=self.hidden_dim)
-        self.optimizer = torch.optim.Adam(self.non_linear_evaluator.parameters(),
+        self.evaluator = SSLEvaluator(n_input=self.z_dim,
+                                      n_classes=self.num_classes,
+                                      p=self.drop_p,
+                                      n_hidden=self.hidden_dim)
+        self.optimizer = torch.optim.Adam(self.evaluator.parameters(),
                                           lr=self.learning_rate,
                                           weight_decay=self.weight_decay)
 
@@ -61,16 +64,16 @@ class SSLOnlineEvaluatorInnerEye(SSLOnlineEvaluator):
                            checkpoint: Dict[str, Any]) -> Dict[str, Any]:
         # Each callback gets its own state dictionary, that are fed back in during load
         return {
-            OPTIMIZER_STATE_NAME: self.optimizer.state_dict(),
-            EVALUATOR_STATE_NAME: self.non_linear_evaluator.state_dict()
+            self.OPTIMIZER_STATE_NAME: self.optimizer.state_dict(),
+            self.EVALUATOR_STATE_NAME: self.evaluator.state_dict()
         }
 
     def on_load_checkpoint(self,
                            trainer: pl.Trainer,
                            pl_module: pl.LightningModule,
                            callback_state: Dict[str, Any]) -> None:
-        self.optimizer.load_state_dict(callback_state[OPTIMIZER_STATE_NAME])
-        self.non_linear_evaluator.load_state_dict(callback_state[EVALUATOR_STATE_NAME])
+        self.optimizer.load_state_dict(callback_state[self.OPTIMIZER_STATE_NAME])
+        self.evaluator.load_state_dict(callback_state[self.EVALUATOR_STATE_NAME])
 
     def on_pretrain_routine_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
         """
@@ -78,7 +81,16 @@ class SSLOnlineEvaluatorInnerEye(SSLOnlineEvaluator):
         """
         for metric in [*self.train_metrics, *self.val_metrics]:
             metric.to(device=pl_module.device)  # type: ignore
-        self.non_linear_evaluator.to(pl_module.device)
+        self.evaluator.to(pl_module.device)
+        accelerator = trainer.accelerator_connector
+        if accelerator.is_distributed:
+            if accelerator.use_ddp:
+                self.evaluator = DistributedDataParallel(self.evaluator, device_ids=[pl_module.device])
+            elif accelerator.use_dp:
+                self.evaluator = DataParallel(self.evaluator, device_ids=[pl_module.device])
+            else:
+                rank_zero_warn("This type of distributed accelerator is not supported. "
+                               "The online evaluator will not synchronize across GPUs.")
 
     @staticmethod
     def to_device(batch: Any, device: Union[str, torch.device]) -> Tuple[T, T]:
@@ -108,7 +120,7 @@ class SSLOnlineEvaluatorInnerEye(SSLOnlineEvaluator):
         representations = representations.detach()
 
         # Run the linear-head with SSL embeddings.
-        mlp_preds = self.non_linear_evaluator(representations)
+        mlp_preds = self.evaluator(representations)
         weights = None if self.class_weights is None else self.class_weights.to(device=pl_module.device)
         mlp_loss = F.cross_entropy(mlp_preds, y, weight=weights)
 
@@ -133,15 +145,11 @@ class SSLOnlineEvaluatorInnerEye(SSLOnlineEvaluator):
         ids_linear_head = tuple(batch[SSLDataModuleType.LINEAR_HEAD][0].tolist())
         if ids_linear_head not in self.visited_ids:
             self.visited_ids.add(ids_linear_head)
-            # Put the online evaluator into "eval" mode
-            old_mode = self.non_linear_evaluator.training
-            self.non_linear_evaluator.eval()
-            loss = self.shared_step(batch, pl_module, is_training=False)
-            log_on_epoch(pl_module, 'ssl_online_evaluator/val/loss', loss)
-            for metric in self.val_metrics:
-                log_on_epoch(pl_module, f"ssl_online_evaluator/val/{metric.name}", metric)
-            # Put the online evaluator back into the state (eval or train) that it was before calling this method
-            self.non_linear_evaluator.train(old_mode)
+            with set_model_to_eval_mode(self.evaluator):
+                loss = self.shared_step(batch, pl_module, is_training=False)
+                log_on_epoch(pl_module, 'ssl_online_evaluator/val/loss', loss)
+                for metric in self.val_metrics:
+                    log_on_epoch(pl_module, f"ssl_online_evaluator/val/{metric.name}", metric)
 
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx) -> None:  # type: ignore
         """

--- a/InnerEye/ML/SSL/lightning_modules/ssl_online_evaluator.py
+++ b/InnerEye/ML/SSL/lightning_modules/ssl_online_evaluator.py
@@ -11,7 +11,7 @@ from pl_bolts.callbacks.ssl_online import SSLOnlineEvaluator
 from pl_bolts.models.self_supervised.evaluator import SSLEvaluator
 from pytorch_lightning.utilities import rank_zero_warn
 from torch import Tensor as T
-from torch.nn import DataParallel, functional as F
+from torch.nn import functional as F
 from torch.nn.parallel import DistributedDataParallel
 from torchmetrics import Metric
 

--- a/InnerEye/ML/SSL/lightning_modules/ssl_online_evaluator.py
+++ b/InnerEye/ML/SSL/lightning_modules/ssl_online_evaluator.py
@@ -85,9 +85,9 @@ class SSLOnlineEvaluatorInnerEye(SSLOnlineEvaluator):
         accelerator = trainer.accelerator_connector
         if accelerator.is_distributed:
             if accelerator.use_ddp:
-                self.evaluator = DistributedDataParallel(self.evaluator, device_ids=[pl_module.device])
+                self.evaluator = DistributedDataParallel(self.evaluator, device_ids=[pl_module.device])  # type: ignore
             elif accelerator.use_dp:
-                self.evaluator = DataParallel(self.evaluator, device_ids=[pl_module.device])
+                self.evaluator = DataParallel(self.evaluator, device_ids=[pl_module.device])  # type: ignore
             else:
                 rank_zero_warn("This type of distributed accelerator is not supported. "
                                "The online evaluator will not synchronize across GPUs.")

--- a/InnerEye/ML/utils/layer_util.py
+++ b/InnerEye/ML/utils/layer_util.py
@@ -2,7 +2,8 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  ------------------------------------------------------------------------------------------
-from typing import Iterable, Sized, Tuple, Union
+from contextlib import contextmanager
+from typing import Generator, Iterable, Sized, Tuple, Union
 
 import torch
 from torch.nn import init
@@ -90,3 +91,16 @@ def get_upsampling_kernel_size(downsampling_factor: IntOrTuple3, num_dimensions:
                               upsample_size(downsampling_factor[1]),  # type: ignore
                               upsample_size(downsampling_factor[2]))  # type: ignore
     return upsampling_kernel_size
+
+
+@contextmanager
+def set_model_to_eval_mode(model: torch.nn.Module) -> Generator:
+    """
+    Puts the given torch model into eval mode. At the end of the context, resets the state of the training flag to
+    what is was before the call.
+    :param model: The model to modify.
+    """
+    old_mode = model.training
+    model.eval()
+    yield
+    model.train(old_mode)

--- a/InnerEye/ML/utils/model_util.py
+++ b/InnerEye/ML/utils/model_util.py
@@ -3,9 +3,8 @@
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  ------------------------------------------------------------------------------------------
 import logging
-from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Dict, Generator, Generic, Iterator, List, Optional, TypeVar, Union
+from typing import Any, Dict, Generic, Iterator, List, Optional, TypeVar, Union
 
 import torch
 from torch.nn import MSELoss
@@ -322,16 +321,3 @@ def get_scalar_model_inputs_and_labels(model: torch.nn.Module,
             subject_ids=subject_ids,
             data_item=scalar_item
         )
-
-
-@contextmanager
-def set_model_to_eval_mode(model: torch.nn.Module) -> Generator:
-    """
-    Puts the given torch model into eval mode. At the end of the context, resets the state of the training flag to
-    what is was before the call.
-    :param model: The model to modify.
-    """
-    old_mode = model.training
-    model.eval()
-    yield
-    model.train(old_mode)

--- a/InnerEye/ML/utils/model_util.py
+++ b/InnerEye/ML/utils/model_util.py
@@ -3,8 +3,9 @@
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  ------------------------------------------------------------------------------------------
 import logging
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, Iterator, List, Optional, TypeVar, Union
+from typing import Any, Dict, Generator, Generic, Iterator, List, Optional, TypeVar, Union
 
 import torch
 from torch.nn import MSELoss
@@ -321,3 +322,16 @@ def get_scalar_model_inputs_and_labels(model: torch.nn.Module,
             subject_ids=subject_ids,
             data_item=scalar_item
         )
+
+
+@contextmanager
+def set_model_to_eval_mode(model: torch.nn.Module) -> Generator:
+    """
+    Puts the given torch model into eval mode. At the end of the context, resets the state of the training flag to
+    what is was before the call.
+    :param model: The model to modify.
+    """
+    old_mode = model.training
+    model.eval()
+    yield
+    model.train(old_mode)

--- a/InnerEye/ML/visualizers/model_summary.py
+++ b/InnerEye/ML/visualizers/model_summary.py
@@ -17,6 +17,7 @@ from InnerEye.Common.common_util import logging_only_to_file
 from InnerEye.Common.fixed_paths import DEFAULT_MODEL_SUMMARIES_DIR_PATH
 from InnerEye.ML.utils.device_aware_module import DeviceAwareModule
 from InnerEye.ML.utils.ml_util import RandomStateSnapshot
+from InnerEye.ML.utils.model_util import set_model_to_eval_mode
 
 
 @dataclass
@@ -217,15 +218,11 @@ def forward_preserve_state(module: DeviceAwareModule, inputs: List[torch.Tensor]
         inputs = [input_tensor.cuda() for input_tensor in inputs]
 
     # collect the current state of the model
-    is_train = module.training
     module_state = RandomStateSnapshot.snapshot_random_state()
 
-    # set the model in evaluation mode and perform a forward pass
-    module.eval()
-    with torch.no_grad():
-        output = module.forward(*inputs)
-    if is_train:
-        module.train()
+    with set_model_to_eval_mode(module):
+        with torch.no_grad():
+            output = module.forward(*inputs)
 
     # restore the seed for torch and numpy
     module_state.restore_random_state()

--- a/InnerEye/ML/visualizers/model_summary.py
+++ b/InnerEye/ML/visualizers/model_summary.py
@@ -17,7 +17,7 @@ from InnerEye.Common.common_util import logging_only_to_file
 from InnerEye.Common.fixed_paths import DEFAULT_MODEL_SUMMARIES_DIR_PATH
 from InnerEye.ML.utils.device_aware_module import DeviceAwareModule
 from InnerEye.ML.utils.ml_util import RandomStateSnapshot
-from InnerEye.ML.utils.model_util import set_model_to_eval_mode
+from InnerEye.ML.utils.layer_util import set_model_to_eval_mode
 
 
 @dataclass

--- a/Tests/SSL/test_ssl_containers.py
+++ b/Tests/SSL/test_ssl_containers.py
@@ -12,7 +12,7 @@ import pandas as pd
 import pytest
 import torch
 from pl_bolts.models.self_supervised.resnets import ResNet
-from pytorch_lightning import Trainer
+from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from torch.nn import Module
 from torch.nn.parallel import DistributedDataParallel
@@ -344,13 +344,11 @@ def test_online_evaluator_recovery(test_output_dirs: OutputFolderForTests) -> No
 
 
 @pytest.mark.gpu
-def test_online_evaluator_distributed() -> None:
+def test_online_evaluator_not_distributed() -> None:
     """
-    A very basic test to check if the online evaluator uses the DDP flag correctly.
+    Check if the online evaluator uses the DDP flag correctly when running not distributed
     """
-    mock_ddp_result = "mock_ddp_result"
-    with mock.patch("InnerEye.ML.SSL.lightning_modules.ssl_online_evaluator.DistributedDataParallel",
-                    return_value=mock_ddp_result) as mock_ddp:
+    with mock.patch("InnerEye.ML.SSL.lightning_modules.ssl_online_evaluator.DistributedDataParallel") as mock_ddp:
         callback = SSLOnlineEvaluatorInnerEye(class_weights=None,
                                               z_dim=1,
                                               num_classes=2,
@@ -361,14 +359,32 @@ def test_online_evaluator_distributed() -> None:
 
         # Standard trainer without DDP
         trainer = Trainer()
+        # Test the flag that the internal logic of on_pretrain_routine_start uses
+        assert not trainer.accelerator_connector.is_distributed
         mock_module = mock.MagicMock(device=torch.device("cpu"))
         callback.on_pretrain_routine_start(trainer, mock_module)
         assert isinstance(callback.evaluator, Module)
         mock_ddp.assert_not_called()
 
+
+@pytest.mark.gpu
+def test_online_evaluator_distributed() -> None:
+    """
+    Check if the online evaluator uses the DDP flag correctly when running distributed.
+    """
+    mock_ddp_result = "mock_ddp_result"
+    with mock.patch("InnerEye.ML.SSL.lightning_modules.ssl_online_evaluator.DistributedDataParallel",
+                    return_value=mock_ddp_result) as mock_ddp:
+        callback = SSLOnlineEvaluatorInnerEye(class_weights=None,
+                                              z_dim=1,
+                                              num_classes=2,
+                                              dataset="foo",
+                                              drop_p=0.2,
+                                              learning_rate=1e-5)
+
         # Trainer with DDP
-        mock_device = "fake_device"
-        mock_module = mock.MagicMock(device=mock_device)
+        device = torch.device("cuda:0")
+        mock_module = mock.MagicMock(device=device)
         trainer = Trainer(accelerator="ddp", gpus=2)
         # Test the two flags that the internal logic of on_pretrain_routine_start uses
         assert trainer.accelerator_connector.is_distributed
@@ -376,5 +392,5 @@ def test_online_evaluator_distributed() -> None:
         callback.on_pretrain_routine_start(trainer, mock_module)
         # Check that the evaluator has been turned into a DDP object
         # We still need to mock DDP here because the constructor relies on having a process group available
-        mock_ddp.assert_called_once_with(callback.evaluator, device_ids=[mock_device])
+        mock_ddp.assert_called_once_with(callback.evaluator, device_ids=[device])
         assert callback.evaluator == mock_ddp_result

--- a/Tests/SSL/test_ssl_containers.py
+++ b/Tests/SSL/test_ssl_containers.py
@@ -12,10 +12,9 @@ import pandas as pd
 import pytest
 import torch
 from pl_bolts.models.self_supervised.resnets import ResNet
-from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from torch.nn import Module
-from torch.nn.parallel import DistributedDataParallel
 from torch.optim.lr_scheduler import _LRScheduler
 
 from InnerEye.Common import fixed_paths

--- a/Tests/SSL/test_ssl_containers.py
+++ b/Tests/SSL/test_ssl_containers.py
@@ -346,7 +346,7 @@ def test_online_evaluator_recovery(test_output_dirs: OutputFolderForTests) -> No
 @pytest.mark.gpu
 def test_online_evaluator_distributed() -> None:
     """
-    A very primitive type of test to check if the online evaluator uses the DDP flag correctly.
+    A very basic test to check if the online evaluator uses the DDP flag correctly.
     """
     with mock.patch("InnerEye.ML.SSL.lightning_modules.ssl_online_evaluator.DistributedDataParallel") as mock_ddp:
         callback = SSLOnlineEvaluatorInnerEye(class_weights=None,

--- a/Tests/SSL/test_ssl_containers.py
+++ b/Tests/SSL/test_ssl_containers.py
@@ -369,5 +369,5 @@ def test_online_evaluator_distributed() -> None:
         mock_module = mock.MagicMock(device=mock_device)
         trainer = Trainer(accelerator="ddp", gpus=2)
         callback.on_pretrain_routine_start(trainer, mock_module)
-        # We still need to make DDP here because the constructor relies on having a process group available
+        # We still need to mock DDP here because the constructor relies on having a process group available
         mock_ddp.assert_called_once_with(callback.evaluator, device_ids=[mock_device])


### PR DESCRIPTION
SSL online evaluator presently is not synchronizing across GPUs. Enable DDP.

Please follow the guidelines for PRs contained [here](docs/pull_requests.md). Checklist:

- [x] Ensure that your PR is small, and implements one change.
- [x] Add unit tests for all functions that you introduced or modified.
- [x] Run PyCharm's code cleanup tools on your Python files.
- [ ] Link the correct GitHub issue for tracking.
- [x] Update the [Changelog](CHANGELOG.md) file: Describe your change in terms of 
Added/Changed/Removed/... in the "Upcoming" section.
- [ ] When merging your PR, replace the default merge message with a description of your PR,
and if needed a motivation why that change was required.
