### PR TITLE
Pre-build docker images for use in PRs

### DIFF
--- a/azure-pipelines/build-pr.yml
+++ b/azure-pipelines/build-pr.yml
@@ -7,6 +7,7 @@ resources:
   containers:
   - container: current
     image: innereye:46176
+    endpoint: BuildAgentACR
 
 name: PR-$(Date:yyyyMMdd)$(Rev:-r)
 variables:

--- a/azure-pipelines/build-pr.yml
+++ b/azure-pipelines/build-pr.yml
@@ -6,8 +6,8 @@ pr:
 resources:
   containers:
   - container: current
-    image: innereye:46176
-    endpoint: BuildAgentACR
+    image: innereye:46186
+    endpoint: BuildAgentACRPremium
 
 name: PR-$(Date:yyyyMMdd)$(Rev:-r)
 variables:

--- a/azure-pipelines/build-pr.yml
+++ b/azure-pipelines/build-pr.yml
@@ -3,6 +3,11 @@ pr:
     include:
     - '*'
 
+resources:
+  containers:
+  - container: current
+    image: innereye:46176
+
 name: PR-$(Date:yyyyMMdd)$(Rev:-r)
 variables:
   model: 'BasicModel2Epochs'
@@ -26,6 +31,7 @@ jobs:
   - job: Linux
     pool:
       vmImage: 'ubuntu-18.04'
+    container: current
     steps:
       - template: build.yaml
 
@@ -37,6 +43,7 @@ jobs:
         value: '--log_level=DEBUG --pl_deterministic --use_dataset_mount=True --regression_test_folder=RegressionTestResults/PR_BasicModel2Epochs'
     pool:
       vmImage: 'ubuntu-18.04'
+    container: current
     steps:
       - template: train_template.yml
         parameters:
@@ -53,6 +60,7 @@ jobs:
         value: 'RunGpuTests'
     pool:
       vmImage: 'ubuntu-18.04'
+    container: current
     steps:
       - template: train_template.yml
         parameters:
@@ -77,6 +85,7 @@ jobs:
         value: 'Train1ChannelSubmodule'
     pool:
       vmImage: 'ubuntu-18.04'
+    container: current
     steps:
       - template: train_via_submodule.yml
         parameters:
@@ -101,6 +110,7 @@ jobs:
         value: '--pl_deterministic --regression_test_folder=RegressionTestResults/PR_TrainEnsemble'
     pool:
       vmImage: 'ubuntu-18.04'
+    container: current
     steps:
       - template: train_template.yml
         parameters:
@@ -123,6 +133,7 @@ jobs:
         value: '--log_level=DEBUG --pl_deterministic --num_nodes=2 --regression_test_folder=RegressionTestResults/PR_Train2Nodes'
     pool:
       vmImage: 'ubuntu-18.04'
+    container: current
     steps:
       - template: train_template.yml
         parameters:
@@ -142,6 +153,7 @@ jobs:
         value: 'HelloWorldPR'
     pool:
       vmImage: 'ubuntu-18.04'
+    container: current
     steps:
       - template: train_template.yml
         parameters:
@@ -161,6 +173,7 @@ jobs:
         value: '--pl_deterministic --num_nodes=2 --max_num_gpus=2 --regression_test_folder=RegressionTestResults/PR_HelloContainer'
     pool:
       vmImage: 'ubuntu-18.04'
+    container: current
     steps:
       - template: train_template.yml
         parameters:
@@ -185,6 +198,7 @@ jobs:
         value: '--pl_deterministic --num_epochs=1 --feature_channels=16 --show_patch_sampling=0 --train_batch_size=4 --inference_on_val_set=False --inference_on_test_set=False '
     pool:
       vmImage: 'ubuntu-18.04'
+    container: current
     steps:
       - template: train_template.yml
         parameters:
@@ -196,5 +210,6 @@ jobs:
   - job: BuildDataSelection
     pool:
       vmImage: 'ubuntu-18.04'
+    container: current
     steps:
       - template: build_data_quality.yaml

--- a/azure-pipelines/build-pr.yml
+++ b/azure-pipelines/build-pr.yml
@@ -23,13 +23,6 @@ variables:
   disable.coverage.autogenerate: 'true'
 
 jobs:
-  - job: LinuxDiagnostics
-    pool:
-      vmImage: 'ubuntu-18.04'
-    steps:
-      - bash: |
-          env
-
   - job: Windows
     pool:
       vmImage: 'windows-2019'

--- a/azure-pipelines/build-pr.yml
+++ b/azure-pipelines/build-pr.yml
@@ -23,6 +23,13 @@ variables:
   disable.coverage.autogenerate: 'true'
 
 jobs:
+  - job: Linux agent diagnostics
+    pool:
+      vmImage: 'ubuntu-18.04'
+    steps:
+      - bash: |
+          env
+
   - job: Windows
     pool:
       vmImage: 'windows-2019'
@@ -34,8 +41,6 @@ jobs:
       vmImage: 'ubuntu-18.04'
     container: current
     steps:
-      - bash: |
-          env
       - template: build.yaml
 
   - job: TrainInAzureML

--- a/azure-pipelines/build-pr.yml
+++ b/azure-pipelines/build-pr.yml
@@ -23,7 +23,7 @@ variables:
   disable.coverage.autogenerate: 'true'
 
 jobs:
-  - job: Linux agent diagnostics
+  - job: LinuxDiagnostics
     pool:
       vmImage: 'ubuntu-18.04'
     steps:

--- a/azure-pipelines/build-pr.yml
+++ b/azure-pipelines/build-pr.yml
@@ -34,6 +34,8 @@ jobs:
       vmImage: 'ubuntu-18.04'
     container: current
     steps:
+      - bash: |
+          env
       - template: build.yaml
 
   - job: TrainInAzureML

--- a/azure-pipelines/build.yaml
+++ b/azure-pipelines/build.yaml
@@ -2,7 +2,7 @@ steps:
   - template: checkout.yml
 
   - bash: |
-      conda env update --file environment.yml --name InnerEye --quiet
+      sudo conda env update --file environment.yml --name InnerEye --quiet
       source activate InnerEye
       echo Storing environment for later use by ComponentGovernance
       # This file is picked up later by ComponentGovernance

--- a/azure-pipelines/build.yaml
+++ b/azure-pipelines/build.yaml
@@ -2,7 +2,7 @@ steps:
   - template: checkout.yml
 
   - bash: |
-      conda env create --file environment.yml --name InnerEye --quiet
+      conda env update --file environment.yml --name InnerEye --quiet
       source activate InnerEye
       echo Storing environment for later use by ComponentGovernance
       # This file is picked up later by ComponentGovernance

--- a/azure-pipelines/checkout.yml
+++ b/azure-pipelines/checkout.yml
@@ -2,21 +2,3 @@ steps:
   - checkout: self
     lfs: true
     submodules: true
-
-  - bash: |
-      subdir=bin
-      echo "Adding this directory to PATH: $CONDA/$subdir"
-      echo "##vso[task.prependpath]$CONDA/$subdir"
-    displayName: Add conda to PATH
-    condition: succeeded()
-
-  - bash: |
-      conda install conda=4.8.3 -y
-      conda --version
-      conda list
-    displayName: Print conda version and initial package list
-
-  - bash: |
-      sudo chown -R $USER /usr/share/miniconda
-    condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ))
-    displayName: Take ownership of conda installation

--- a/azure-pipelines/checkout.yml
+++ b/azure-pipelines/checkout.yml
@@ -2,3 +2,7 @@ steps:
   - checkout: self
     lfs: true
     submodules: true
+
+  - bash: |
+      chown -R $USER /opt/conda/envs
+    displayName: Take ownership of conda installation

--- a/azure-pipelines/checkout.yml
+++ b/azure-pipelines/checkout.yml
@@ -4,5 +4,5 @@ steps:
     submodules: true
 
   - bash: |
-      chown -R $USER /opt/conda/envs
+      chown -R `whoami` /opt/conda/envs
     displayName: Take ownership of conda installation

--- a/azure-pipelines/docker_build.yml
+++ b/azure-pipelines/docker_build.yml
@@ -1,0 +1,15 @@
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+  - bash: |
+      cp environment.yml docker/
+    displayName: Copy InnerEye environment file
+
+  - task: Docker@2
+    displayName: Build and Push
+    inputs:
+      command: buildAndPush
+      containerRegistry: BuildAgentACR
+      repository: innereye
+      Dockerfile: 'docker/Dockerfile'

--- a/azure-pipelines/docker_build.yml
+++ b/azure-pipelines/docker_build.yml
@@ -10,6 +10,6 @@ steps:
     displayName: Build and Push
     inputs:
       command: buildAndPush
-      containerRegistry: BuildAgentACR
+      containerRegistry: BuildAgentACRPremium
       repository: innereye
       Dockerfile: 'docker/Dockerfile'

--- a/azure-pipelines/inner_eye_env.yml
+++ b/azure-pipelines/inner_eye_env.yml
@@ -4,7 +4,7 @@ steps:
   - template: store_settings.yml
 
   - bash: |
-      conda env create --file environment.yml --name InnerEye
+      conda env update --file environment.yml --name InnerEye
       source activate InnerEye
       pip freeze
     failOnStderr: false

--- a/azure-pipelines/inner_eye_env.yml
+++ b/azure-pipelines/inner_eye_env.yml
@@ -4,7 +4,7 @@ steps:
   - template: store_settings.yml
 
   - bash: |
-      conda env update --file environment.yml --name InnerEye
+      sudo conda env update --file environment.yml --name InnerEye
       source activate InnerEye
       pip freeze
     failOnStderr: false

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM continuumio/miniconda3:latest
+
+MAINTAINER antonsc@microsoft.com
+
+# Environment file is copied to this folder by the build definition
+COPY ./environment.yml /tmp
+
+RUN conda env create --file /tmp/environment.yml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,10 +4,15 @@ MAINTAINER antonsc@microsoft.com
 
 RUN apt-get -y update
 
-# Installing psutil requires gcc
-RUN apt-get -y install gcc
+# Installing psutil requires gcc. Install sudo to help with permissions problems
+RUN apt-get -y install \
+    gcc \
+    sudo
 
 # Environment file is copied to this folder by the build definition
 COPY ./environment.yml /tmp
 
-RUN conda env create --file /tmp/environment.yml
+RUN conda env create --file /tmp/environment.yml \
+    && conda clean --all \
+    # Ensure everyone has write permissions, because we need to update the environment in the build pipeline
+    && chmod -R a+w /opt/conda/envs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,3 @@ RUN apt-get -y install gcc
 COPY ./environment.yml /tmp
 
 RUN conda env create --file /tmp/environment.yml
-
-# Allow write access to this conda environment because the build agents will later try to update the environment
-RUN chmod a+w /opt/conda/envs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,4 +11,6 @@ RUN apt-get -y install gcc
 COPY ./environment.yml /tmp
 
 RUN conda env create --file /tmp/environment.yml
+
+# Allow write access to this conda environment because the build agents will later try to update the environment
 RUN chmod a+w /opt/conda/envs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,3 +11,4 @@ RUN apt-get -y install gcc
 COPY ./environment.yml /tmp
 
 RUN conda env create --file /tmp/environment.yml
+RUN chmod a+w /opt/conda/envs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,11 @@ FROM continuumio/miniconda3:latest
 
 MAINTAINER antonsc@microsoft.com
 
+RUN apt-get -y update
+
+# Installing psutil requires gcc
+RUN apt-get -y install gcc
+
 # Environment file is copied to this folder by the build definition
 COPY ./environment.yml /tmp
 

--- a/environment.yml
+++ b/environment.yml
@@ -44,7 +44,6 @@ dependencies:
       - papermill==2.2.2
       - param==1.9.3
       - pillow==8.3.2
-      - psutil==5.7.2
       - pydicom==2.0.0
       - pyflakes==2.2.0
       - PyJWT==1.7.1

--- a/environment.yml
+++ b/environment.yml
@@ -44,6 +44,7 @@ dependencies:
       - papermill==2.2.2
       - param==1.9.3
       - pillow==8.3.2
+      - psutil==5.7.2
       - pydicom==2.0.0
       - pyflakes==2.2.0
       - PyJWT==1.7.1


### PR DESCRIPTION
Adding this PR only for reference - #618 turned out to be a lot faster and easier to use.
This PR adds
- A build definition that builds a Docker image and pushes it to an Azure Container Registry
- Updates to all build steps to consume the docker image

What is not yet working: There's a permissions issue, the conda environment can't be updated
Also, this is suprisingly slow to consume. Consuming the docker image takes between 4 and 10min, even when using a premium tier ACR.
