### PR TITLE
Fix length problem in SSL Cosine LR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ in inference-only runs when using lightning containers.
   weights from a finetuning run were incompatible with the model architecture created for non-finetuning runs.
 - ([#604](https://github.com/microsoft/InnerEye-DeepLearning/pull/604)) Fix issue where runs on a VM would download the dataset even when a local dataset is provided.
 - ([#628](https://github.com/microsoft/InnerEye-DeepLearning/pull/628)) SSL SimCLR using the wrong LR schedule when running on multiple nodes
+- ([#638](https://github.com/microsoft/InnerEye-DeepLearning/pull/638)) SimClr cosine LR scheduler was using wrong length information when using with long linear head datasets
 - ([#612](https://github.com/microsoft/InnerEye-DeepLearning/pull/612)) SSL online evaluator was not doing distributed training
 
 ### Removed

--- a/InnerEye/ML/SSL/datamodules_and_datasets/datamodules.py
+++ b/InnerEye/ML/SSL/datamodules_and_datasets/datamodules.py
@@ -155,7 +155,7 @@ class CombinedDataModule(LightningDataModule):
         return CombinedLoader(dataloaders, mode="max_size_cycle")
 
     @property
-    def num_samples(self) -> int:
+    def num_train_samples(self) -> int:
         """
         Returns number of samples in training set
         """

--- a/InnerEye/ML/SSL/encoders.py
+++ b/InnerEye/ML/SSL/encoders.py
@@ -80,9 +80,8 @@ def get_encoder_output_dim(
             SSLOnlineEvaluatorInnerEye,
         )
 
-        dataloader = dm.train_dataloader()
-        dataloader = dataloader[SSLDataModuleType.LINEAR_HEAD] if isinstance(dataloader, dict) else dataloader  # type: ignore
-        batch = iter(dataloader).next()  # type: ignore
+        batch = next(iter(dm.train_dataloader()))
+        batch = batch[SSLDataModuleType.LINEAR_HEAD] if isinstance(batch, dict) else batch  # type: ignore
         x, _ = SSLOnlineEvaluatorInnerEye.to_device(batch, device)
     else:
         x = torch.rand((1, 3, 256, 256)).to(device)

--- a/InnerEye/ML/SSL/lightning_containers/ssl_container.py
+++ b/InnerEye/ML/SSL/lightning_containers/ssl_container.py
@@ -172,7 +172,6 @@ class SSLContainer(LightningContainer):
                 f"Found {self.ssl_training_type.value}")
         model.hparams.update({'ssl_type': self.ssl_training_type.value,
                               "num_classes": self.data_module.num_classes})
-        print(vars(model))
         self.encoder_output_dim = get_encoder_output_dim(model, self.data_module)
         return model
 
@@ -185,10 +184,6 @@ class SSLContainer(LightningContainer):
             return self.data_module
         encoder_data_module = self._create_ssl_data_modules(is_ssl_encoder_module=True)
         linear_data_module = self._create_ssl_data_modules(is_ssl_encoder_module=False)
-        encoder_loader = encoder_data_module.train_dataloader()
-        head_loader = linear_data_module.train_dataloader()
-        print(f"Encoder: {len(encoder_loader)} training batches")
-        print(f"Linear head: {len(head_loader)} training batches")
         return CombinedDataModule(encoder_data_module, linear_data_module,
                                   self.use_balanced_binary_loss_for_linear_head)
 

--- a/InnerEye/ML/SSL/lightning_containers/ssl_container.py
+++ b/InnerEye/ML/SSL/lightning_containers/ssl_container.py
@@ -185,6 +185,10 @@ class SSLContainer(LightningContainer):
             return self.data_module
         encoder_data_module = self._create_ssl_data_modules(is_ssl_encoder_module=True)
         linear_data_module = self._create_ssl_data_modules(is_ssl_encoder_module=False)
+        encoder_loader = encoder_data_module.train_dataloader()
+        head_loader = linear_data_module.train_dataloader()
+        print(f"Encoder: {len(encoder_loader)} training batches")
+        print(f"Linear head: {len(head_loader)} training batches")
         return CombinedDataModule(encoder_data_module, linear_data_module,
                                   self.use_balanced_binary_loss_for_linear_head)
 

--- a/InnerEye/ML/SSL/lightning_containers/ssl_container.py
+++ b/InnerEye/ML/SSL/lightning_containers/ssl_container.py
@@ -157,6 +157,7 @@ class SSLContainer(LightningContainer):
                                                     num_nodes=self.num_nodes,
                                                     learning_rate=self.l_rate,
                                                     max_epochs=self.num_epochs)
+            logging.info(f"LR scheduling is using train_iters_per_epoch = {model.train_iters_per_epoch}")
         elif self.ssl_training_type == SSLTrainingType.BYOL:
             model = BYOLInnerEye(encoder_name=self.ssl_encoder.value,
                                  num_samples=self.data_module.num_train_samples,

--- a/InnerEye/ML/SSL/lightning_containers/ssl_container.py
+++ b/InnerEye/ML/SSL/lightning_containers/ssl_container.py
@@ -172,7 +172,7 @@ class SSLContainer(LightningContainer):
                 f"Found {self.ssl_training_type.value}")
         model.hparams.update({'ssl_type': self.ssl_training_type.value,
                               "num_classes": self.data_module.num_classes})
-
+        print(vars(model))
         self.encoder_output_dim = get_encoder_output_dim(model, self.data_module)
         return model
 

--- a/InnerEye/ML/SSL/lightning_containers/ssl_container.py
+++ b/InnerEye/ML/SSL/lightning_containers/ssl_container.py
@@ -151,7 +151,7 @@ class SSLContainer(LightningContainer):
             model: LightningModule = SimCLRInnerEye(encoder_name=self.ssl_encoder.value,
                                                     dataset_name=self.ssl_training_dataset_name.value,
                                                     use_7x7_first_conv_in_resnet=use_7x7_first_conv_in_resnet,
-                                                    num_samples=self.data_module.num_samples,
+                                                    num_samples=self.data_module.num_train_samples,
                                                     batch_size=self.data_module.batch_size,
                                                     gpus=self.num_gpus_per_node(),
                                                     num_nodes=self.num_nodes,
@@ -159,7 +159,7 @@ class SSLContainer(LightningContainer):
                                                     max_epochs=self.num_epochs)
         elif self.ssl_training_type == SSLTrainingType.BYOL:
             model = BYOLInnerEye(encoder_name=self.ssl_encoder.value,
-                                 num_samples=self.data_module.num_samples,
+                                 num_samples=self.data_module.num_train_samples,
                                  batch_size=self.data_module.batch_size,
                                  learning_rate=self.l_rate,
                                  use_7x7_first_conv_in_resnet=use_7x7_first_conv_in_resnet,

--- a/InnerEye/ML/SSL/lightning_modules/simclr_module.py
+++ b/InnerEye/ML/SSL/lightning_modules/simclr_module.py
@@ -49,7 +49,6 @@ class SimCLRInnerEye(SimCLR):
         """
         if "dataset" not in kwargs:  # needed for the new version of lightning-bolts
             kwargs.update({"dataset": dataset_name})
-        print(kwargs)
         super().__init__(**kwargs)
         self.save_hyperparameters()
         self.encoder = SSLEncoder(encoder_name, use_7x7_first_conv_in_resnet)

--- a/InnerEye/ML/SSL/lightning_modules/simclr_module.py
+++ b/InnerEye/ML/SSL/lightning_modules/simclr_module.py
@@ -49,6 +49,7 @@ class SimCLRInnerEye(SimCLR):
         """
         if "dataset" not in kwargs:  # needed for the new version of lightning-bolts
             kwargs.update({"dataset": dataset_name})
+        print(kwargs)
         super().__init__(**kwargs)
         self.save_hyperparameters()
         self.encoder = SSLEncoder(encoder_name, use_7x7_first_conv_in_resnet)

--- a/Tests/AfterTraining/test_after_training.py
+++ b/Tests/AfterTraining/test_after_training.py
@@ -27,7 +27,7 @@ from InnerEye.Azure.azure_util import MODEL_ID_KEY_NAME, download_run_output_fil
     download_run_outputs_by_prefix, \
     get_comparison_baseline_paths, \
     is_running_on_azure_agent, to_azure_friendly_string
-from InnerEye.Common import common_util, fixed_paths, fixed_paths_for_tests
+from InnerEye.Common import fixed_paths, fixed_paths_for_tests
 from InnerEye.Common.common_util import BEST_EPOCH_FOLDER_NAME, CROSSVAL_RESULTS_FOLDER, ENSEMBLE_SPLIT_NAME, \
     get_best_epoch_results_path
 from InnerEye.Common.fixed_paths import (DEFAULT_AML_UPLOAD_DIR, DEFAULT_RESULT_IMAGE_NAME,
@@ -292,7 +292,6 @@ def _check_presence_cross_val_metrics_file(split: str, mode: ModelExecutionMode,
     return f"{CROSSVAL_RESULTS_FOLDER}/{split}/{mode.value}/metrics.csv" in available_files
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on Windows")
 @pytest.mark.after_training_glaucoma_cv_run
 def test_expected_cv_files_classification(test_output_dirs: OutputFolderForTests) -> None:
     run = get_most_recent_run(fallback_run_id_for_local_execution=FALLBACK_CV_GLAUCOMA)
@@ -309,7 +308,6 @@ def test_expected_cv_files_classification(test_output_dirs: OutputFolderForTests
     assert crossval_report_file in available_files
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on Windows")
 @pytest.mark.after_training_ensemble_run
 def test_expected_cv_files_segmentation() -> None:
     run = get_most_recent_run(fallback_run_id_for_local_execution=FALLBACK_ENSEMBLE_RUN)
@@ -323,7 +321,6 @@ def test_expected_cv_files_segmentation() -> None:
     assert not _check_presence_cross_val_metrics_file(ENSEMBLE_SPLIT_NAME, ModelExecutionMode.VAL, available_files)
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on Windows")
 @pytest.mark.after_training_ensemble_run
 def test_register_and_score_model(test_output_dirs: OutputFolderForTests) -> None:
     """

--- a/Tests/ML/datasets/test_dataloader_speed.py
+++ b/Tests/ML/datasets/test_dataloader_speed.py
@@ -8,7 +8,6 @@ from io import StringIO
 import pandas as pd
 import pytest
 
-from InnerEye.Common.common_util import is_windows
 from InnerEye.Common.output_directories import OutputFolderForTests
 from InnerEye.ML.dataset.scalar_dataset import ScalarDataset
 from InnerEye.ML.dataset.scalar_sample import ScalarItem
@@ -18,8 +17,6 @@ from InnerEye.ML.utils import ml_util
 
 @pytest.mark.parametrize("num_dataload_workers", [0, 1])
 @pytest.mark.parametrize("shuffle", [False, True])
-@pytest.mark.skipif(is_windows(),
-                    reason="This test runs fine on local Windows boxes, but leads to odd timeouts in Azure")
 def test_dataloader_speed(test_output_dirs: OutputFolderForTests,
                           num_dataload_workers: int,
                           shuffle: bool) -> None:

--- a/Tests/ML/datasets/test_dataset.py
+++ b/Tests/ML/datasets/test_dataset.py
@@ -229,7 +229,6 @@ def test_cropping_dataset_sample_dtype(cropping_dataset: CroppingDataset, num_da
         assert item.labels_center_crop.numpy().dtype == ImageDataType.SEGMENTATION.value
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Has issues on windows build")
 def test_cropping_dataset_padding(cropping_dataset: CroppingDataset, num_dataload_workers: int) -> None:
     """
     Tests the data type of torch tensors (e.g. image, labels, and mask) created by the dataset generator,

--- a/Tests/ML/datasets/test_scalar_dataset.py
+++ b/Tests/ML/datasets/test_scalar_dataset.py
@@ -15,7 +15,6 @@ import pytest
 import torch
 from pandas.util.testing import assert_frame_equal
 
-from InnerEye.Common import common_util
 from InnerEye.Common.fixed_paths_for_tests import full_ml_test_data_path
 from InnerEye.Common.output_directories import OutputFolderForTests
 from InnerEye.Common.type_annotations import TupleInt3
@@ -769,7 +768,6 @@ def test_categorical_and_numerical_columns_are_mutually_exclusive(test_output_di
                              categorical_columns=["scalar1"])
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 def test_imbalanced_sampler() -> None:
     # Simulate a highly imbalanced dataset with only one data point
     # with a negative label.

--- a/Tests/ML/datasets/test_sequence_dataset.py
+++ b/Tests/ML/datasets/test_sequence_dataset.py
@@ -13,7 +13,6 @@ import pandas as pd
 import pytest
 import torch
 
-from InnerEye.Common.common_util import is_windows
 from InnerEye.Common.output_directories import OutputFolderForTests
 from InnerEye.ML.common import ModelExecutionMode
 from InnerEye.ML.dataset.full_image_dataset import collate_with_metadata
@@ -342,8 +341,6 @@ def test_filter_valid_items() -> None:
 
 
 # noinspection PyUnresolvedReferences
-@pytest.mark.skipif(is_windows(),
-                    reason="This test runs fine on local Windows boxes, but leads to odd timeouts in Azure")
 def test_sequence_dataloader() -> None:
     """
     Test if we can create a data loader from the dataset, and recover the items as expected in batched form.

--- a/Tests/ML/models/architectures/sequential/test_rnn_classifier.py
+++ b/Tests/ML/models/architectures/sequential/test_rnn_classifier.py
@@ -12,7 +12,6 @@ import pytest
 import torch
 from torchvision.transforms import ColorJitter, RandomAffine
 
-from InnerEye.Common import common_util
 from InnerEye.Common.common_util import SUBJECT_METRICS_FILE_NAME, logging_to_stdout
 from InnerEye.Common.fixed_paths_for_tests import full_ml_test_data_path
 from InnerEye.Common.metrics_constants import LoggingColumns, MetricType, SEQUENCE_POSITION_HUE_NAME_PREFIX
@@ -220,7 +219,6 @@ def test_rnn_classifier_via_config_1(use_combined_model: bool,
         model_train_unittest(config, output_folder=test_output_dirs)
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Has issues on windows build")
 @pytest.mark.parametrize(["use_combined_model", "imaging_feature_type"],
                          [(False, ImagingFeatureType.Image),
                           (True, ImagingFeatureType.Image),
@@ -253,7 +251,6 @@ def test_run_ml_with_sequence_model(use_combined_model: bool,
         MLRunner(config, azure_config=azure_config).run()
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize(["use_combined_model", "imaging_feature_type"],
                          [(False, ImagingFeatureType.Image),
                           (True, ImagingFeatureType.Image),
@@ -356,13 +353,12 @@ class ToySequenceModel2(SequenceModelBase):
                              target_indices=self.get_target_indices())
 
 
-# Only test the non-combined model because otherwise the build takes too much time.
-@pytest.mark.skipif(common_util.is_windows(), reason="Has issues on windows build")
 @pytest.mark.gpu
 def test_rnn_classifier_via_config_2(test_output_dirs: OutputFolderForTests) -> None:
     """
     Test if we can build an RNN classifier that learns sequences, of the same kind as in
     test_rnn_classifier_toy_problem, but built via the config.
+    Only test the non-combined model because otherwise the build takes too much time.
     """
     expected_max_train_loss = 0.71
     expected_max_val_loss = 0.71
@@ -434,7 +430,6 @@ class ToyMultiLabelSequenceModel(SequenceModelBase):
                              target_indices=self.get_target_indices())
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Has issues on windows build")
 def test_run_ml_with_multi_label_sequence_model(test_output_dirs: OutputFolderForTests) -> None:
     """
     Test training and testing of sequence models that predicts at multiple time points,

--- a/Tests/ML/models/architectures/test_image_encoder_with_mlp.py
+++ b/Tests/ML/models/architectures/test_image_encoder_with_mlp.py
@@ -14,7 +14,6 @@ import pytest
 import torch
 from torchvision.transforms import ColorJitter, RandomAffine
 
-from InnerEye.Common import common_util
 from InnerEye.Common.common_util import logging_to_stdout
 from InnerEye.Common.output_directories import OutputFolderForTests
 from InnerEye.Common.type_annotations import TupleInt3
@@ -122,7 +121,6 @@ class ImageEncoder(ScalarModelBase):
         return ModelTransformsPerExecutionMode()
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize(["encode_channels_jointly", "use_non_imaging_features",
                           "reduction_factor", "expected_num_reduced_features",
                           "kernel_size_per_encoding_block", "stride_size_per_encoding_block",
@@ -237,7 +235,6 @@ S3,week1,scan3.npy,True,6,60,Male,Val2
     # from having invalid model architectures, which would throw runtime errors during training.
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.gpu
 @pytest.mark.parametrize(["encode_channels_jointly", "aggregation_type", "imaging_feature_type"],
                          [(False, AggregationType.Average, ImagingFeatureType.Segmentation),
@@ -329,7 +326,6 @@ def test_segmentation_to_one_hot(use_gpu: bool, input_on_gpu: bool) -> None:
             assert one_hot[:, i, ...].float().allclose(expected), f"Dimension {i} should have all ones"
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize("encode_channels_jointly", [True, False])
 @pytest.mark.parametrize("use_non_imaging_features", [True, False])
 @pytest.mark.parametrize("imaging_feature_type", [ImagingFeatureType.Image,

--- a/Tests/ML/models/architectures/test_non_image_encoder_with_mlp.py
+++ b/Tests/ML/models/architectures/test_non_image_encoder_with_mlp.py
@@ -8,7 +8,6 @@ from typing import Any, Optional
 import pandas as pd
 import pytest
 
-from InnerEye.Common import common_util
 from InnerEye.Common.output_directories import OutputFolderForTests
 from InnerEye.ML.common import DATASET_CSV_FILE_NAME
 from InnerEye.ML.models.architectures.classification.image_encoder_with_mlp import create_mlp
@@ -55,7 +54,6 @@ class NonImageEncoder(ScalarModelBase):
                           hidden_layer_num_feature_channels=self.hidden_layer_num_feature_channels)
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Has issue on Windows build")
 @pytest.mark.parametrize("hidden_layer_num_feature_channels", [None, 2])
 def test_non_image_encoder(test_output_dirs: OutputFolderForTests,
                            hidden_layer_num_feature_channels: Optional[int]) -> None:

--- a/Tests/ML/models/architectures/test_unet_3d.py
+++ b/Tests/ML/models/architectures/test_unet_3d.py
@@ -7,7 +7,6 @@ import logging
 import pytest
 import torch
 
-from InnerEye.Common import common_util
 from InnerEye.ML.models.architectures.unet_3d import UNet3D
 from InnerEye.ML.visualizers.model_summary import ModelSummary
 from Tests.ML.util import machine_has_gpu, no_gpu_available
@@ -27,7 +26,6 @@ def test_unet_summary_generation() -> None:
     assert summary is not None
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Has issues on windows build")
 @pytest.mark.gpu
 def test_unet_model_parallel() -> None:
     """Checks model parallel utilises all the available GPU devices for forward pass"""

--- a/Tests/ML/models/test_parallel.py
+++ b/Tests/ML/models/test_parallel.py
@@ -8,7 +8,6 @@ import pytest
 import torch
 from torch import Tensor
 
-from InnerEye.Common import common_util
 from InnerEye.ML.models.architectures.base_model import BaseSegmentationModel, CropSizeConstraints
 from InnerEye.ML.models.parallel.model_parallel import group_layers_with_balanced_memory, \
     move_to_device, partition_layers
@@ -46,7 +45,6 @@ class SimpleModel(BaseSegmentationModel):
         return list(self._model.children())
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Has issues on windows build")
 @pytest.mark.gpu
 @pytest.mark.skipif(no_gpu, reason="CUDA capable GPU is not available")
 def test_move_to_device() -> None:

--- a/Tests/ML/models/test_scalar_model.py
+++ b/Tests/ML/models/test_scalar_model.py
@@ -255,7 +255,6 @@ def check_log_file(path: Path, expected_csv: str, ignore_columns: List[str]) -> 
     pd.testing.assert_frame_equal(df_expected, df_epoch_metrics_actual, check_less_precise=True, check_like=True)
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize("model_name", ["DummyClassification", "DummyRegression"])
 @pytest.mark.parametrize("number_of_offline_cross_validation_splits", [2])
 def test_run_ml_with_classification_model(test_output_dirs: OutputFolderForTests,
@@ -291,7 +290,6 @@ def test_run_ml_with_classification_model(test_output_dirs: OutputFolderForTests
             assert file.metrics_file.exists()
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 def test_run_ml_with_segmentation_model(test_output_dirs: OutputFolderForTests) -> None:
     """
     Test training and testing of segmentation models, when it is started together via run_ml.
@@ -365,7 +363,6 @@ def test_runner2(test_output_dirs: OutputFolderForTests) -> None:
     assert config.name.startswith("DummyClassification")
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Has issues on windows build")
 @pytest.mark.gpu
 @pytest.mark.parametrize(["output_values_list", "expected_accuracy"],
                          [([0.4, 0.9], 1.0),

--- a/Tests/ML/pipelines/test_forward_pass.py
+++ b/Tests/ML/pipelines/test_forward_pass.py
@@ -5,13 +5,11 @@
 
 import pytest
 
-from InnerEye.Common import common_util
 from InnerEye.ML.deep_learning_config import DeepLearningConfig, TrainerParams
 from InnerEye.ML.lightning_container import LightningContainer
 from Tests.ML.util import machine_has_gpu
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Has issues on windows build")
 @pytest.mark.cpu_and_gpu
 @pytest.mark.parametrize("config", [DeepLearningConfig(should_validate=False),
                                     LightningContainer()])

--- a/Tests/ML/pipelines/test_inference.py
+++ b/Tests/ML/pipelines/test_inference.py
@@ -11,7 +11,6 @@ import pytest
 import torch
 from torch.nn import Parameter
 
-from InnerEye.Common import common_util
 from InnerEye.Common.output_directories import OutputFolderForTests
 from InnerEye.Common.type_annotations import TupleInt3
 from InnerEye.ML.config import SegmentationModelBase
@@ -27,7 +26,6 @@ from InnerEye.ML.common import ModelExecutionMode
 from InnerEye.ML.model_testing import store_inference_results, evaluate_model_predictions, populate_metrics_writer
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize("image_size", [(4, 4, 4), (4, 6, 8)])
 @pytest.mark.parametrize("crop_size", [(5, 5, 5), (3, 3, 3), (3, 5, 7)])
 def test_inference_image_and_crop_size(image_size: Any,
@@ -38,7 +36,6 @@ def test_inference_image_and_crop_size(image_size: Any,
                        test_output_dirs=test_output_dirs)
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize("shrink_by", [(0, 0, 0), (1, 1, 1), (1, 0, 1)])
 def test_inference_shrink_y(shrink_by: Any,
                             test_output_dirs: OutputFolderForTests) -> None:
@@ -46,7 +43,6 @@ def test_inference_shrink_y(shrink_by: Any,
                        test_output_dirs=test_output_dirs)
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize("num_classes", [1, 5])
 def test_inference_num_classes(num_classes: int,
                                test_output_dirs: OutputFolderForTests) -> None:
@@ -54,7 +50,6 @@ def test_inference_num_classes(num_classes: int,
                        test_output_dirs=test_output_dirs)
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize("create_mask", [True, False])
 def test_inference_create_mask(create_mask: bool,
                                test_output_dirs: OutputFolderForTests) -> None:
@@ -62,7 +57,6 @@ def test_inference_create_mask(create_mask: bool,
                        test_output_dirs=test_output_dirs)
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize("extract_largest_foreground_connected_component", [True, False])
 def test_inference_component(extract_largest_foreground_connected_component: bool,
                              test_output_dirs: OutputFolderForTests) -> None:
@@ -70,7 +64,6 @@ def test_inference_component(extract_largest_foreground_connected_component: boo
                        test_output_dirs=test_output_dirs)
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize("is_ensemble", [True, False])
 def test_inference_ensemble(is_ensemble: bool,
                             test_output_dirs: OutputFolderForTests) -> None:
@@ -78,7 +71,6 @@ def test_inference_ensemble(is_ensemble: bool,
                        test_output_dirs=test_output_dirs)
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize("posterior_smoothing_mm", [None, (0.05, 0.06, 0.1)])
 def test_inference_smoothing(posterior_smoothing_mm: Any,
                              test_output_dirs: OutputFolderForTests) -> None:

--- a/Tests/ML/pipelines/test_inference_smallimages.py
+++ b/Tests/ML/pipelines/test_inference_smallimages.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from InnerEye.Common.common_util import is_windows
 from InnerEye.Common.output_directories import OutputFolderForTests
 from InnerEye.Common.type_annotations import TupleInt3
 from InnerEye.ML.config import SegmentationModelBase
@@ -60,7 +59,6 @@ def run_inference_on_unet(size: TupleInt3) -> None:
         image_util.check_array_range(p)
 
 
-@pytest.mark.skipif(is_windows(), reason="Too slow on windows")
 def test_inference_on_too_small_image() -> None:
     """
     Running inference on a simplified Unet model when the input image is too small along an axis.
@@ -70,7 +68,6 @@ def test_inference_on_too_small_image() -> None:
     assert "input image must have at least a size of (16, 16, 16)" in str(ex)
 
 
-@pytest.mark.skipif(is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize("size", [(26, 20, 50), (16, 16, 16)])
 def test_inference_on_small_image(size: TupleInt3) -> None:
     """

--- a/Tests/ML/reports/test_classification_multilabel_report.py
+++ b/Tests/ML/reports/test_classification_multilabel_report.py
@@ -6,11 +6,9 @@ from pathlib import Path
 
 import pandas as pd
 import numpy as np
-import pytest
 
 from InnerEye.Common.metrics_constants import LoggingColumns
 from InnerEye.Common.output_directories import OutputFolderForTests
-from InnerEye.Common.common_util import is_windows
 from InnerEye.ML.configs.classification.DummyMulticlassClassification import DummyMulticlassClassification
 from InnerEye.ML.metrics_dict import MetricsDict
 from InnerEye.ML.reports.classification_multilabel_report import get_dataframe_with_exact_label_matches, \
@@ -21,7 +19,6 @@ from InnerEye.ML.common import ModelExecutionMode
 from InnerEye.Azure.azure_util import DEFAULT_CROSS_VALIDATION_SPLIT_INDEX
 
 
-@pytest.mark.skipif(is_windows(), reason="Random timeout errors on windows.")
 def test_generate_classification_multilabel_report(test_output_dirs: OutputFolderForTests) -> None:
     hues = ["Hue1", "Hue2"]
 
@@ -63,7 +60,8 @@ def test_generate_classification_multilabel_report(test_output_dirs: OutputFolde
                             config.channel_column: ["image1", "image2"] * 6,
                             config.image_file_column: [f for f in [f"0_{image_file_name}", f"1_{image_file_name}"]
                                                        for _ in range(6)],
-                            config.label_value_column: ["", "", "1", "1", "1", "1", "0|1", "0|1", "0|1", "0|1", "0", "0"]
+                            config.label_value_column: ["", "", "1", "1", "1", "1", "0|1", "0|1", "0|1", "0|1", "0",
+                                                        "0"]
                             }).to_csv(dataset_csv_path, index=False)
 
     np.save(str(Path(config.local_dataset / f"0_{image_file_name}")),
@@ -104,8 +102,8 @@ def test_get_pseudo_labels_and_predictions_multiple_hues(test_output_dirs: Outpu
     hues = ["Hue1", "Hue2"]
     csv.loc[::2, LoggingColumns.Hue.value] = hues[0]
     csv.loc[1::2, LoggingColumns.Hue.value] = hues[1]
-    csv.loc[::2, LoggingColumns.Patient.value] = list(range(len(csv)//2))
-    csv.loc[1::2, LoggingColumns.Patient.value] = list(range(len(csv)//2))
+    csv.loc[::2, LoggingColumns.Patient.value] = list(range(len(csv) // 2))
+    csv.loc[1::2, LoggingColumns.Patient.value] = list(range(len(csv) // 2))
     csv.loc[::2, LoggingColumns.Label.value] = [0, 0, 0, 1, 1, 1]
     csv.loc[1::2, LoggingColumns.Label.value] = [0, 1, 1, 1, 1, 0]
     csv.loc[::2, LoggingColumns.ModelOutput.value] = [0.1, 0.1, 0.1, 0.9, 0.9, 0.9]
@@ -126,7 +124,6 @@ def test_get_pseudo_labels_and_predictions_multiple_hues(test_output_dirs: Outpu
 
 
 def test_generate_pseudo_labels() -> None:
-
     metrics_df = pd.DataFrame.from_dict({"prediction_target": ["Hue1", "Hue2", "Hue3"] * 4,
                                          "epoch": [0] * 12,
                                          "subject": [i for i in range(4) for _ in range(3)],
@@ -149,7 +146,6 @@ def test_generate_pseudo_labels() -> None:
 
 
 def test_generate_pseudo_labels_negative_class() -> None:
-
     metrics_df = pd.DataFrame.from_dict({"prediction_target": ["Hue1", "Hue2", "Hue3"] * 4,
                                          "epoch": [0] * 12,
                                          "subject": [i for i in range(4) for _ in range(3)],

--- a/Tests/ML/runners/test_runner.py
+++ b/Tests/ML/runners/test_runner.py
@@ -156,7 +156,6 @@ def create_mock_run(mock_upload_path: Path, config: DeepLearningConfig) -> Run:
     return run
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize("perform_cross_validation", [True, False])
 def test_model_inference_train_and_test_default(test_output_dirs: OutputFolderForTests,
                                                 perform_cross_validation: bool) -> None:
@@ -172,7 +171,6 @@ def test_model_inference_train_and_test_default(test_output_dirs: OutputFolderFo
                                        model_proc=ModelProcessing.DEFAULT)
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize("perform_cross_validation", [True, False])
 @pytest.mark.parametrize("inference_on_set", [(True, False, False), (False, True, False), (False, False, True)])
 def test_model_inference_train_and_test(test_output_dirs: OutputFolderForTests,
@@ -195,7 +193,6 @@ def test_model_inference_train_and_test(test_output_dirs: OutputFolderForTests,
                                        model_proc=ModelProcessing.DEFAULT)
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 def test_ensemble_model_inference_train_and_test_default(test_output_dirs: OutputFolderForTests) -> None:
     """
     Test inference defaults with ModelProcessing.ENSEMBLE_CREATION.
@@ -208,7 +205,6 @@ def test_ensemble_model_inference_train_and_test_default(test_output_dirs: Outpu
                                        model_proc=ModelProcessing.ENSEMBLE_CREATION)
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize("ensemble_inference_on_set", [(True, False, False), (False, True, False), (False, False, True)])
 def test_ensemble_model_inference_train_and_test(test_output_dirs: OutputFolderForTests,
                                                  ensemble_inference_on_set: Tuple[bool, bool, bool]) -> None:

--- a/Tests/ML/test_model_testing.py
+++ b/Tests/ML/test_model_testing.py
@@ -8,7 +8,6 @@ import pandas as pd
 import pytest
 from pytorch_lightning import seed_everything
 
-from InnerEye.Common import common_util
 from InnerEye.Common.common_util import METRICS_AGGREGATES_FILE, SUBJECT_METRICS_FILE_NAME, get_best_epoch_results_path
 from InnerEye.Common.fixed_paths_for_tests import full_ml_test_data_path
 from InnerEye.Common.metrics_constants import MetricsFileColumns
@@ -31,7 +30,6 @@ from Tests.ML.util import (assert_file_contains_string, assert_nifti_content, as
 from Tests.ML.utils.test_model_util import create_model_and_store_checkpoint
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Too slow on windows")
 @pytest.mark.parametrize(["use_partial_ground_truth", "allow_partial_ground_truth"], [[True, True], [True, False], [False, False]])
 def test_model_test(
         test_output_dirs: OutputFolderForTests,

--- a/Tests/ML/visualizers/test_regression_visualization.py
+++ b/Tests/ML/visualizers/test_regression_visualization.py
@@ -5,14 +5,11 @@
 import os
 
 import numpy as np
-import pytest
 
-from InnerEye.Common import common_util
 from InnerEye.Common.output_directories import OutputFolderForTests
 from InnerEye.ML.visualizers.regression_visualization import plot_variation_error_prediction
 
 
-@pytest.mark.skipif(common_util.is_windows(), reason="Test execution time is longer on Windows")
 def test_plot_variation_errors_for_regression(test_output_dirs: OutputFolderForTests) -> None:
     plot_variation_error_prediction(
         labels=np.array([10, 20, 20, 40, 10, 60, 90]),

--- a/Tests/ML/visualizers/test_reliability_curve.py
+++ b/Tests/ML/visualizers/test_reliability_curve.py
@@ -3,13 +3,10 @@
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  ------------------------------------------------------------------------------------------
 import numpy as np
-import pytest
 
-from InnerEye.Common import common_util
 from InnerEye.ML.visualizers.reliability_curve import plot_reliability_curve
 
 
-@pytest.mark.skipif(not common_util.is_linux(), reason="Test execution time is longer on Windows")
 def test_plot_reliability_curve() -> None:
     prediction = [np.random.rand(250, 1), np.random.rand(200, 1)]
     target = [np.random.randint(2, size=(250, 1)), np.random.randint(2, size=(200, 1))]

--- a/Tests/SSL/byol/test_byol_moving_average.py
+++ b/Tests/SSL/byol/test_byol_moving_average.py
@@ -15,9 +15,9 @@ from torch.utils.data import DataLoader
 from InnerEye.ML.SSL.datamodules_and_datasets.cxr_datasets import RSNAKaggleCXR
 from InnerEye.ML.SSL.lightning_modules.byol.byol_module import BYOLInnerEye
 from InnerEye.ML.SSL.lightning_modules.byol.byol_moving_average import ByolMovingAverageWeightUpdate
-from Tests.SSL.test_ssl_containers import _create_test_cxr_data, path_to_test_dataset
+from Tests.SSL.test_ssl_containers import create_cxr_test_dataset, path_to_cxr_test_dataset
 
-_create_test_cxr_data(path_to_test_dataset)
+create_cxr_test_dataset(path_to_cxr_test_dataset)
 
 
 def test_update_tau() -> None:
@@ -27,7 +27,7 @@ def test_update_tau() -> None:
                     torch.rand([3, 224, 224], dtype=torch.float32)), \
                    randint(0, 1)
 
-    dataset_dir = str(path_to_test_dataset)
+    dataset_dir = str(path_to_cxr_test_dataset)
     dummy_rsna_train_dataloader: DataLoader = torch.utils.data.DataLoader(
         DummyRSNADataset(root=dataset_dir, return_index=False, train=True),
         batch_size=20,

--- a/Tests/SSL/byol/test_byol_moving_average.py
+++ b/Tests/SSL/byol/test_byol_moving_average.py
@@ -17,8 +17,6 @@ from InnerEye.ML.SSL.lightning_modules.byol.byol_module import BYOLInnerEye
 from InnerEye.ML.SSL.lightning_modules.byol.byol_moving_average import ByolMovingAverageWeightUpdate
 from Tests.SSL.test_ssl_containers import create_cxr_test_dataset, path_to_cxr_test_dataset
 
-create_cxr_test_dataset(path_to_cxr_test_dataset)
-
 
 def test_update_tau() -> None:
     class DummyRSNADataset(RSNAKaggleCXR):
@@ -27,6 +25,7 @@ def test_update_tau() -> None:
                     torch.rand([3, 224, 224], dtype=torch.float32)), \
                    randint(0, 1)
 
+    create_cxr_test_dataset(path_to_cxr_test_dataset)
     dataset_dir = str(path_to_cxr_test_dataset)
     dummy_rsna_train_dataloader: DataLoader = torch.utils.data.DataLoader(
         DummyRSNADataset(root=dataset_dir, return_index=False, train=True),

--- a/Tests/SSL/test_data_modules.py
+++ b/Tests/SSL/test_data_modules.py
@@ -212,7 +212,7 @@ def test_combined_data_module() -> None:
 
     assert combined_loader.num_classes == 2
     # num samples has to return number of training samples in encoder data.
-    assert combined_loader.num_samples == 240
+    assert combined_loader.num_train_samples == 240
     # we don't want to compute the weights for balanced loss
     assert combined_loader.class_weights is None
 

--- a/Tests/SSL/test_data_modules.py
+++ b/Tests/SSL/test_data_modules.py
@@ -20,10 +20,10 @@ from InnerEye.ML.SSL.datamodules_and_datasets.transforms_utils import InnerEyeCI
 from InnerEye.ML.SSL.lightning_containers.ssl_container import SSLContainer, SSLDatasetName
 from InnerEye.ML.SSL.utils import SSLDataModuleType, load_yaml_augmentation_config
 from InnerEye.ML.configs.ssl.CXR_SSL_configs import path_encoder_augmentation_cxr
-from Tests.SSL.test_ssl_containers import _create_test_cxr_data
+from Tests.SSL.test_ssl_containers import create_cxr_test_dataset
 
 path_to_test_dataset = full_ml_test_data_path("cxr_test_dataset")
-_create_test_cxr_data(path_to_test_dataset)
+create_cxr_test_dataset(path_to_test_dataset)
 cxr_augmentation_config = load_yaml_augmentation_config(path_encoder_augmentation_cxr)
 
 

--- a/Tests/SSL/test_data_modules.py
+++ b/Tests/SSL/test_data_modules.py
@@ -2,15 +2,11 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 #  ------------------------------------------------------------------------------------------
-from typing import Dict
-
 import PIL
 import numpy as np
-import pytest
 import torch
 from pytorch_lightning.trainer.supporters import CombinedLoader
 
-from InnerEye.Common.common_util import is_windows
 from InnerEye.Common.fixed_paths_for_tests import full_ml_test_data_path
 from InnerEye.ML.SSL.datamodules_and_datasets.cifar_datasets import InnerEyeCIFAR10
 from InnerEye.ML.SSL.datamodules_and_datasets.cxr_datasets import RSNAKaggleCXR
@@ -27,7 +23,6 @@ create_cxr_test_dataset(path_to_test_dataset)
 cxr_augmentation_config = load_yaml_augmentation_config(path_encoder_augmentation_cxr)
 
 
-@pytest.mark.skipif(is_windows(), reason="Too slow on windows")
 def test_weights_innereye_module() -> None:
     """
     Tests if weights in CXR data module are correctly initialized
@@ -55,7 +50,6 @@ def test_weights_innereye_module() -> None:
     assert images_v1.shape == images_v2.shape == torch.Size([1, 3, 224, 224])
 
 
-@pytest.mark.skipif(is_windows(), reason="Too slow on windows")
 def test_innereye_vision_module() -> None:
     """
     Test properties of loaded CIFAR datasets via InnerEyeVisionDataModule.
@@ -92,7 +86,6 @@ def test_innereye_vision_module() -> None:
     assert labels.tolist() == [7, 9, 1, 5, 7]
 
 
-@pytest.mark.skipif(is_windows(), reason="Too slow on windows")
 def test_innereye_vision_datamodule_with_return_index() -> None:
     """
     Tests that the return index flag, modifies __getitem__ as expected i.e.
@@ -116,8 +109,7 @@ def test_innereye_vision_datamodule_with_return_index() -> None:
     assert labels.tolist() == [6, 2, 8, 6, 6]
 
 
-@pytest.mark.skipif(is_windows(), reason="Too slow on windows")
-def test_get_transforms_in_SSL_container_for_cxr_data() -> None:
+def test_get_transforms_in_ssl_container_for_cxr_data() -> None:
     """
     Tests that the internal _get_transforms function returns data of the expected type of CXR.
     Tests that is_ssl_encoder_module induces the correct type of transform pipeline (dual vs single view).
@@ -148,7 +140,6 @@ def test_get_transforms_in_SSL_container_for_cxr_data() -> None:
     assert v1.shape == torch.Size([3, 224, 224])
 
 
-@pytest.mark.skipif(is_windows(), reason="Too slow on windows")
 def test_get_transforms_in_SSL_container_for_cifar_data() -> None:
     """
     Tests that the internal _get_transforms function returns data of the expected type of CXR.
@@ -175,7 +166,6 @@ def test_get_transforms_in_SSL_container_for_cifar_data() -> None:
     assert v1.shape == torch.Size([3, 32, 32])
 
 
-@pytest.mark.skipif(is_windows(), reason="Too slow on windows")
 def test_combined_data_module() -> None:
     """
     Tests the behavior of CombinedDataModule
@@ -192,7 +182,8 @@ def test_combined_data_module() -> None:
                                                 data_dir=str(path_to_test_dataset),
                                                 # 300 images in total in test dataset
                                                 batch_size=20,
-                                                shuffle=False)
+                                                shuffle=False,
+                                                num_workers=0)
     long_data_module.setup()
     # Datamodule expected to have 4 training batches - 1 val
     short_data_module = InnerEyeVisionDataModule(dataset_cls=RSNAKaggleCXR,
@@ -203,7 +194,8 @@ def test_combined_data_module() -> None:
                                                  data_dir=str(path_to_test_dataset),
                                                  # 300 images in total in test dataset
                                                  batch_size=60,
-                                                 shuffle=False)
+                                                 shuffle=False,
+                                                 num_workers=0)
     short_data_module.setup()
 
     combined_loader = CombinedDataModule(encoder_module=long_data_module,
@@ -224,25 +216,13 @@ def test_combined_data_module() -> None:
     assert torch.isclose(combined_loader.class_weights,
                          torch.tensor([0.21, 0.79], dtype=torch.float32), atol=1e-3).all()
 
-    # PyTorch Lightning expects a dictionary of loader at training time.
-    # It will take care of "filling in the gaps" automatically in the trainer
-    # (i.e. matching the length of the shortest dataloader to the length of the
-    # longest).
-    train_dataloaders = combined_loader.train_dataloader()
-    assert isinstance(train_dataloaders, Dict)
-    assert len(train_dataloaders[SSLDataModuleType.ENCODER]) == 12
-    assert len(train_dataloaders[SSLDataModuleType.LINEAR_HEAD]) == 4
+    train_dataloader = combined_loader.train_dataloader()
+    assert isinstance(train_dataloader, CombinedLoader)
 
-    # Weirdly, in PL the handling of combined loader is different in validation
-    # stage. There, it is expected to return an object of type "CombinedDataLoader" that
-    # takes care of the aggregation of batches.
     indices_classifier_module_short = []
     val_dataloader = combined_loader.val_dataloader()
     assert isinstance(val_dataloader, CombinedLoader)
     for batch in val_dataloader:
         assert set(batch.keys()) == {SSLDataModuleType.ENCODER, SSLDataModuleType.LINEAR_HEAD}
         indices_classifier_module_short.append(tuple(batch[SSLDataModuleType.LINEAR_HEAD][0].tolist()))
-    # Check that combined dataloader fills in the shorter datamodule to match the number of batches of the longest one
-    # by looping from the beginning again.
-    assert len(val_dataloader) == 3
     assert len(set(indices_classifier_module_short)) == 1

--- a/Tests/SSL/test_ssl_containers.py
+++ b/Tests/SSL/test_ssl_containers.py
@@ -13,12 +13,11 @@ import pytest
 import torch
 from pl_bolts.models.self_supervised.resnets import ResNet
 from pl_bolts.optimizers import linear_warmup_decay
-from pytorch_lightning import LightningDataModule, LightningModule, Trainer
+from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.trainer.supporters import CombinedLoader
 from torch.nn import Module
 from torch.optim.lr_scheduler import _LRScheduler
-from torch.utils.data import DataLoader, Dataset
 
 from InnerEye.Common import fixed_paths
 from InnerEye.Common.fixed_paths import repository_root_directory
@@ -36,7 +35,6 @@ from InnerEye.ML.configs.ssl.CXR_SSL_configs import CXRImageClassifier, NIH_RSNA
 from InnerEye.ML.runner import Runner
 from Tests.ML.configs.lightning_test_containers import DummyContainerWithModel
 from Tests.ML.utils.test_io_util import write_test_dicom
-from health_ml.utils import AzureMLProgressBar
 
 path_to_cxr_test_dataset = TEST_OUTPUTS_PATH / "cxr_test_dataset"
 

--- a/Tests/SSL/test_ssl_containers.py
+++ b/Tests/SSL/test_ssl_containers.py
@@ -49,9 +49,9 @@ def create_cxr_test_dataset(path_to_test_dataset: Path,
     :param num_encoder_images: The number of unlabelled images that the dataset should contain (for encoder training)
     :param num_labelled_images: The number of labelled images that the dataset should contain (for the linear head).
     """
-    if path_to_test_dataset.exists():
+    if path_to_test_dataset.is_dir():
         return
-    path_to_test_dataset.mkdir(exist_ok=True)
+    path_to_test_dataset.mkdir(exist_ok=True, parents=True)
     df = pd.DataFrame({"Image Index": np.repeat("1.dcm", num_encoder_images)})
     df.to_csv(path_to_test_dataset / "Data_Entry_2017.csv", index=False)
     df = pd.DataFrame({"subject": np.repeat("1", num_labelled_images),

--- a/Tests/SSL/test_ssl_containers.py
+++ b/Tests/SSL/test_ssl_containers.py
@@ -96,7 +96,6 @@ def _compare_stored_metrics(runner: Runner, expected_metrics: Dict[str, float], 
             assert actual == expected, f"Mismatch for metric {metric}"
 
 
-@pytest.mark.skipif(is_windows(), reason="Too slow on windows")
 def test_innereye_ssl_container_cifar10_resnet_simclr() -> None:
     """
     Tests:


### PR DESCRIPTION
SimCLR cosine LR scheduler was getting wrong length information when the linear head dataset was longer than the encoder dataset.
Also, removed lots of obsolete `pytest.skipif.is_windows()` annotations.

Closes #636 

Please follow the guidelines for PRs contained [here](docs/pull_requests.md). Checklist:

- [x] Ensure that your PR is small, and implements one change.
- [x] Add unit tests for all functions that you introduced or modified.
- [x] Run PyCharm's code cleanup tools on your Python files.
- [x] Link the correct GitHub issue for tracking.
- [x] Update the [Changelog](CHANGELOG.md) file: Describe your change in terms of 
Added/Changed/Removed/... in the "Upcoming" section.
- [x] When merging your PR, replace the default merge message with a description of your PR,
and if needed a motivation why that change was required.
