### PR TITLE
Specify `formatter_class=argparse.ArgumentDefaultsHelpFormatter` in `generic_parsing.py` to show default values for arguments in help message

### DIFF
--- a/InnerEye/Common/generic_parsing.py
+++ b/InnerEye/Common/generic_parsing.py
@@ -146,7 +146,7 @@ class GenericConfig(param.Parameterized):
         Creates an ArgumentParser with all fields of the given argparser that are overridable.
         :return: ArgumentParser
         """
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         cls.add_args(parser)
 
         return parser


### PR DESCRIPTION
This PR addresses issue #675 .

Now, default argument values are shown in the help message, for example:
```[bash]
-h, --help                           show this help message and exit
--subscription_id SUBSCRIPTION_ID    The ID of your Azure subscription. (default: )
[...]
--docker_shm_size DOCKER_SHM_SIZE    The shared memory in the docker image for the AzureML VMs. (default: 440g)
--hyperdrive [HYPERDRIVE]            If True, use AzureML HyperDrive for run execution. (default: False)
```
note that some outputs are empty instead of showing a value of `None`, should this behavior be changed?

PR Checklist:

- [x] Ensure that your PR is small, and implements one change.
- [ ] Add unit tests for all functions that you introduced or modified.
- [x] Run PyCharm's code cleanup tools on your Python files.
- [x] Link the correct GitHub issue for tracking.
- [ ] Update the [Changelog](CHANGELOG.md) file: Describe your change in terms of 
Added/Changed/Removed/... in the "Upcoming" section.
- [ ] When merging your PR, replace the default merge message with a description of your PR,
and if needed a motivation why that change was required.
