### PR TITLE
Add submodules to sys.path to fix autodoc's "No module named 'health_azure'"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ gets uploaded to AzureML, by skipping all test folders.
 
 ### Fixed
 
+- ([#702](https://github.com/microsoft/InnerEye-DeepLearning/pull/702)) Fix autodoc's "No module named 'health_azure'".
 - ([#699](https://github.com/microsoft/InnerEye-DeepLearning/pull/699)) Fix Sphinx warnings.
 - ([#682](https://github.com/microsoft/InnerEye-DeepLearning/pull/682)) Ensure the shape of input patches is compatible with model constraints.
 - ([#681](https://github.com/microsoft/InnerEye-DeepLearning/pull/681)) Pad model outputs if they are smaller than the inputs.

--- a/sphinx-docs/source/conf.py
+++ b/sphinx-docs/source/conf.py
@@ -17,8 +17,11 @@
 #
 import sys
 from pathlib import Path
+
 repo_dir = Path(__file__).absolute().parents[2]
 sys.path.insert(0, str(repo_dir))
+from InnerEye.Common import fixed_paths
+fixed_paths.add_submodules_to_path()
 
 
 # -- Imports -----------------------------------------------------------------
@@ -26,12 +29,12 @@ from recommonmark.parser import CommonMarkParser
 
 # -- Project information -----------------------------------------------------
 
-project = 'InnerEye-DeepLearning'
-copyright = 'Microsoft Corporation'
-author = 'Microsoft'
+project = "InnerEye-DeepLearning"
+copyright = "Microsoft Corporation"
+author = "Microsoft"
 
 # The full version, including alpha/beta/rc tags
-release = '1.0.0'
+release = "1.0.0"
 
 
 # -- General configuration ---------------------------------------------------
@@ -40,14 +43,14 @@ release = '1.0.0'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx_rtd_theme',
-    'recommonmark',
-    'sphinx.ext.viewcode'
+    "sphinx.ext.autodoc",
+    "sphinx_rtd_theme",
+    "recommonmark",
+    "sphinx.ext.viewcode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -60,7 +63,7 @@ exclude_patterns = []  # type: ignore
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -68,10 +71,10 @@ html_theme = 'sphinx_rtd_theme'
 # html_static_path = ['_static']
 
 source_parsers = {
-    '.md': CommonMarkParser,
+    ".md": CommonMarkParser,
 }
 
 source_suffix = {
-    '.rst': 'restructuredtext',
-    '.md': 'markdown',
+    ".rst": "restructuredtext",
+    ".md": "markdown",
 }


### PR DESCRIPTION
Hi @fepegar ! I ran `make html` from your new branch and noticed I was still getting the following warning:

```
WARNING: autodoc: failed to import class 'config.SegmentationModelBase' from module '[InnerEye.ML](http://innereye.ml/)'; the following exception was raised:
Traceback (most recent call last):
  File "/cis/home/jteneggi/anaconda3/envs/InnerEye/lib/python3.7/site-packages/sphinx/util/inspect.py", line 324, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: module '[InnerEye.ML](http://innereye.ml/)' has no attribute 'config'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/cis/home/jteneggi/anaconda3/envs/InnerEye/lib/python3.7/site-packages/sphinx/ext/autodoc/importer.py", line 71, in import_object
    obj = attrgetter(obj, attrname)
  File "/cis/home/jteneggi/anaconda3/envs/InnerEye/lib/python3.7/site-packages/sphinx/ext/autodoc/__init__.py", line 246, in get_attr
    return autodoc_attrgetter(self.env.app, obj, name, *defargs)
  File "/cis/home/jteneggi/anaconda3/envs/InnerEye/lib/python3.7/site-packages/sphinx/ext/autodoc/__init__.py", line 2078, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/cis/home/jteneggi/anaconda3/envs/InnerEye/lib/python3.7/site-packages/sphinx/util/inspect.py", line 340, in safe_getattr
    raise AttributeError(name)
AttributeError: config
WARNING: autodoc: failed to import module 'config' from module '[InnerEye.ML](http://innereye.ml/)'; the following exception was raised:
No module named 'health_azure'
```

I propose to call `fixed_paths.add_submodules_to_path()` in `conf.py` as in `ML/runner.py` to make sure all submodules are imported correctly.
