### PR TITLE
Import submodules to sys.path to fix autodoc's warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ gets uploaded to AzureML, by skipping all test folders.
 
 ### Fixed
 
+- ([#704](https://github.com/microsoft/InnerEye-DeepLearning/pull/704)) Add submodules to sys.path to fix autodoc's warning.
 - ([#699](https://github.com/microsoft/InnerEye-DeepLearning/pull/699)) Fix Sphinx warnings.
 - ([#682](https://github.com/microsoft/InnerEye-DeepLearning/pull/682)) Ensure the shape of input patches is compatible with model constraints.
 - ([#681](https://github.com/microsoft/InnerEye-DeepLearning/pull/681)) Pad model outputs if they are smaller than the inputs.

--- a/sphinx-docs/source/conf.py
+++ b/sphinx-docs/source/conf.py
@@ -19,6 +19,8 @@ import sys
 from pathlib import Path
 repo_dir = Path(__file__).absolute().parents[2]
 sys.path.insert(0, str(repo_dir))
+from InnerEye.Common import fixed_paths
+fixed_paths.add_submodules_to_path()
 
 
 # -- Imports -----------------------------------------------------------------


### PR DESCRIPTION
This PR (see #702) addresses an autodoc warning regarding missing submodules