### PR TITLE
ENH: Enforce prefixes for pull request titles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,19 @@
-Write a detailed description of your PR here.
+Please make sure to follow all the tasks in the checklist below. Then, delete this line and write a detailed description of your pull request here.
 
-Please follow the guidelines for PRs contained [here](docs/pull_requests.md). Checklist:
+<!--
+## Guidelines
 
-- [ ] Ensure that your PR is small, and implements one change.
-- [ ] Add unit tests for all functions that you introduced or modified.
-- [ ] Run PyCharm's code cleanup tools on your Python files.
-- [ ] Link the correct GitHub issue for tracking.
-- [ ] When merging your PR, replace the default merge message with a description of your PR,
-and if needed a motivation why that change was required.
+Please follow the guidelines for pull requests (PRs) in [CONTRIBUTING](/docs/contributing.md). Checklist:
+
+- Ensure that your PR is small, and implements one change
+- Give your PR title one of the prefixes ENH, BUG, STYLE, DOC, DEL to indicate what type of change that is (see [CONTRIBUTING](/docs/contributing.md))
+- Link the correct GitHub issue for tracking
+- Add unit tests for all functions that you introduced or modified
+- Run automatic code formatting / linting on all files ("Format Document" Shift-Alt-F in VSCode)
+- Ensure that documentation renders correctly in Sphinx by running `make html` in the `docs` folder
+
+## Change the default merge message
+
+When completing your PR, you will be asked for a title and an optional extended description. By default, the extended description will be a concatenation of the individual
+commit messages. Please DELETE/REPLACE that with a human readable extended description for non-trivial PRs.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,6 @@ Please follow the guidelines for pull requests (PRs) in [CONTRIBUTING](/docs/con
 - Link the correct GitHub issue for tracking
 - Add unit tests for all functions that you introduced or modified
 - Run automatic code formatting / linting on all files ("Format Document" Shift-Alt-F in VSCode)
-- Ensure that documentation renders correctly in Sphinx by running `make html` in the `docs` folder
 
 ## Change the default merge message
 

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,17 @@
+name: 'Check pull request title'
+on:
+  pull_request:
+    types: [edited, opened, synchronize, reopened]
+
+jobs:
+  title-check:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+    steps:
+      - uses: naveenk1223/action-pr-title@master
+        with:
+          regex: '^[A-Z]+\:\s[A-Z].+'  # Regex the title should match.
+          allowed_prefixes: 'ENH,BUG,STYLE,DOC,DEL'  # title should start with the given prefix
+          prefix_case_sensitive: true  # title prefixes are case ensitive
+          min_length: 10  # Min length of the title
+          max_length: 72  # Max length of the title

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: naveenk1223/action-pr-title@master
         with:
-          regex: '^[A-Z]+\:\s[A-Z].+'  # Regex the title should match.
+          regex: '^[A-Z]+\:\s[A-Z].+[^\.]$'  # Regex the title should match.
           allowed_prefixes: 'ENH,BUG,STYLE,DOC,DEL'  # title should start with the given prefix
           prefix_case_sensitive: true  # title prefixes are case ensitive
           min_length: 10  # Min length of the title

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,7 +1,9 @@
 # Contributing
+
 This document describes guidelines for contributing to the InnerEye-DeepLearning repo.
 
-## Submitting Pull Requests
+## Submitting pull requests
+
 - DO submit all changes via pull requests (PRs). They will be reviewed and potentially be merged by maintainers after a peer review that includes at least one of the team members.
 - DO give PRs short but descriptive names.
 - DO write a useful but brief description of what the PR is for.
@@ -12,26 +14,38 @@ This document describes guidelines for contributing to the InnerEye-DeepLearning
 - DO NOT submit "work in progress" PRs. A PR should only be submitted when it is considered ready for review.
 - DO NOT mix independent and unrelated changes in one PR.
 
-## Coding Style
+To enable good auto-generated changelogs, we prefix all PR titles with a category string, like "BUG: Out of bounds error when using small images".
+Those category prefixes must be in upper case, followed by a colon (`:`). Valid categories are
+
+- `ENH` for enhancements, new capabilities
+- `BUG` for bugfixes
+- `STYLE` for stylistic changes (for example, refactoring) that does not impact the functionality
+- `DOC` for changes to documentation only
+- `DEL` for removing something from the codebase
+
+## Coding style
+
 The coding style is enforced via `flake8` and `mypy`. Before pushing any changes to a PR, run both tools on
 your dev box:
-* `flake8`
-* `python mypy_runner.py`
+
+- `flake8`
+- `python mypy_runner.py`
 
 ## Unit testing
+
 - DO write unit tests for each new function or class that you add.
 - DO extend unit tests for existing functions or classes if you change their core behaviour.
 - DO ensure that your tests are designed in a way that they can pass on the local box, even if they are relying on
 specific cloud features.
 - DO run all unit tests on your dev box before submitting your changes. The test suite is designed to pass completely
 also outside of cloud builds.
-- DO NOT rely only on the test builds in the cloud. Cloud builds trigger AzureML runs on GPU 
+- DO NOT rely only on the test builds in the cloud. Cloud builds trigger AzureML runs on GPU
 machines that have a higher CO2 footprint than your dev box.
 
-## Creating Issues
+## Creating issues
+
 - DO use a descriptive title that identifies the issue or the requested feature.
 - DO write a detailed description of the issue or the requested feature.
-- DO provide details for issues you create:
-    - Describe the expected and actual behavior.
-    - Provide any relevant exception message.
-DO subscribe to notifications for created issues in case there are any follow-up questions.
+- DO provide details for issues you create
+  - Describe the expected and actual behavior.
+  - Provide any relevant exception message.


### PR DESCRIPTION
Resolves #710.
This convention loosely follows the guidelines used in, e.g., [ITK](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#commit-messages).