### PR TITLE
BUG: Fix broken build pipeline by updating package versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
       - azureml-mlflow==1.36.0
       - azureml-sdk==1.36.0
       - azureml-tensorboard==1.36.0
+      - cloudpickle <2.0.0,>=1.1.0
       - conda-merge==0.1.5
       - cryptography==3.3.2
       - cucim==21.10.1; platform_system=="Linux"

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
       - h5py==2.10.0
       - ipython==7.31.1
       - imageio==2.15.0
-      - InnerEye-DICOM-RT==1.0.1
+      - InnerEye-DICOM-RT==1.0.3
       - joblib==0.16.0
       - jupyter==1.0.0
       - jupyter-client==6.1.5


### PR DESCRIPTION
When attempting to merge some other upgrades, the Azure DevOps build pipeline was failing due to incompatible `cloudpickle` and `dotnetcore2` versions.

The error with cloudpickle has been fixed by specifying a suitable range of versions, and the dotnetcore2 error has been fixed by pinning the dependency in InnerEye-DICOM-RT and releasing a new version of it, which this repo is now pinned to (1.0.3).