### PR TITLE
Fix: Ensemble HeadAndNeck model encounters 'CUDA out of memory' 

### DIFF
--- a/InnerEye/ML/pipelines/inference.py
+++ b/InnerEye/ML/pipelines/inference.py
@@ -245,6 +245,7 @@ class InferencePipeline(FullImageInferencePipelineBase):
         :param patient_id: The identifier of the patient this image belongs to (defaults to 0 if None provided).
         :return InferenceResult: that contains Segmentation for each of the classes and their posterior probabilities.
         """
+        torch.cuda.empty_cache()
         if image_channels is None:
             raise Exception("image_channels cannot be None")
         if image_channels.ndim != 4:

--- a/InnerEye/ML/run_ml.py
+++ b/InnerEye/ML/run_ml.py
@@ -740,6 +740,7 @@ class MLRunner:
         else:
             raise NotImplementedError("are_sibling_runs_finished only works for cross validation runs in AzureML.")
 
+    @torch.no_grad()
     def create_ensemble_model_and_run_inference(self) -> None:
         """
         Create an ensemble model from the results of the sibling runs of the present run. The present run here will
@@ -760,6 +761,8 @@ class MLRunner:
                 self.register_model(checkpoint_handler.get_best_checkpoints(), ModelProcessing.ENSEMBLE_CREATION)
 
         if not self.azure_config.only_register_model:
+            if is_global_rank_zero():
+                torch.cuda.empty_cache()
             self.run_inference(checkpoint_paths=checkpoint_handler.get_checkpoints_to_test(),
                                model_proc=ModelProcessing.ENSEMBLE_CREATION)
 


### PR DESCRIPTION
A combination of cache emptying steps and `no_grad` decorator that solves the 'CUDA out of memory' problem faced by some models during inference.

[Link to old run showing out of memory](https://ml.azure.com/experiments/id/963345a6-f18b-4ff8-9f16-f2bb3ed3f46c/runs/HD_17ac3a71-4d07-4311-a500-6762b30b9aa8?wsid=/subscriptions/a85ceddd-892e-4637-ae4b-67d15ddf5f2b/resourceGroups/RadiomicsNN/providers/Microsoft.MachineLearningServices/workspaces/RadiomicsNN&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) - see subsequent runs in that experiment for different solutions attempted

[Link to new run that completed successfully](https://ml.azure.com/experiments/id/963345a6-f18b-4ff8-9f16-f2bb3ed3f46c/runs/HD_71382d21-10a6-4663-9fb8-a815d9eee96c?wsid=/subscriptions/a85ceddd-892e-4637-ae4b-67d15ddf5f2b/resourceGroups/RadiomicsNN/providers/Microsoft.MachineLearningServices/workspaces/RadiomicsNN&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)