### PR TITLE
DOC: Fix RTD Build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,4 +12,4 @@ sphinx:
    configuration: docs/source/conf.py
 
 conda:
-   environment: environment.yml
+   environment: primary_deps.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,5 @@
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for more details
 
 version: 2
 


### PR DESCRIPTION
Closes #828 

The Ubuntu image used by RTD has recently changed and no longer is compatible with the InnerEye locked environment. Getting RTD to use the primary dependencies instead allows it to build correctly.